### PR TITLE
Remove branch filter in CircleCI workflow configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,10 +153,7 @@ workflows:
     jobs:
       - branch_build_approval:
           type: approval
-          filters:
-            branches:
-              ignore:
-                - main
+
       - build:
           requires:
             - branch_build_approval


### PR DESCRIPTION
## What

Fixes issue preventing CircleCI builds from triggering on the main branch
