### PR TITLE
LCAM-107 - Make USN optional field

### DIFF
--- a/crime-means-assessment/src/main/resources/schemas/apiInitMeansAssessmentRequest.json
+++ b/crime-means-assessment/src/main/resources/schemas/apiInitMeansAssessmentRequest.json
@@ -23,7 +23,6 @@
   },
   "additionalProperties": false,
   "required": [
-    "usn",
     "newWorkReason"
   ]
 }

--- a/crime-means-assessment/src/main/resources/schemas/maatApiCreateAssessment.json
+++ b/crime-means-assessment/src/main/resources/schemas/maatApiCreateAssessment.json
@@ -39,7 +39,6 @@
   "required": [
     "nworCode",
     "userCreated",
-    "usn",
     "rtCode"
   ]
 }

--- a/crime-means-assessment/src/main/resources/schemas/maatApiCreateAssessment.json
+++ b/crime-means-assessment/src/main/resources/schemas/maatApiCreateAssessment.json
@@ -36,9 +36,5 @@
     "$ref": "maatApiAssessmentRequest.json"
   },
   "additionalProperties": false,
-  "required": [
-    "nworCode",
-    "userCreated",
-    "rtCode"
-  ]
+  "required": ["nworCode", "userCreated", "rtCode"]
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-107)

-[x] Updated the Init assessment schema to make USN an optional field.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
