### PR TITLE
LCAM-121 - Fix rounding error on adjusted income.

### DIFF
--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/InitMeansAssessmentService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/InitMeansAssessmentService.java
@@ -40,7 +40,7 @@ public class InitMeansAssessmentService implements AssessmentService {
         BigDecimal totalChildWeighting =
                 childWeightingService.getTotalChildWeighting(requestDTO.getChildWeightings(), assessmentCriteria);
         if (BigDecimal.ZERO.compareTo(annualTotal) <= 0) {
-            return annualTotal
+            return annualTotal.setScale(2, RoundingMode.HALF_UP)
                     .divide(assessmentCriteria.getApplicantWeightingFactor()
                                     .add(assessmentCriteria.getPartnerWeightingFactor())
                                     .add(totalChildWeighting),

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/InitMeansAssessmentService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/InitMeansAssessmentService.java
@@ -38,11 +38,12 @@ public class InitMeansAssessmentService implements AssessmentService {
 
     BigDecimal getAdjustedIncome(MeansAssessmentRequestDTO requestDTO, AssessmentCriteriaEntity assessmentCriteria, BigDecimal annualTotal) {
         BigDecimal totalChildWeighting =
-                childWeightingService.getTotalChildWeighting(requestDTO.getChildWeightings(), assessmentCriteria);
+                setStandardScale(childWeightingService.getTotalChildWeighting(requestDTO.getChildWeightings(), assessmentCriteria));
+
         if (BigDecimal.ZERO.compareTo(annualTotal) <= 0) {
-            return annualTotal.setScale(2, RoundingMode.HALF_UP)
-                    .divide(assessmentCriteria.getApplicantWeightingFactor()
-                                    .add(assessmentCriteria.getPartnerWeightingFactor())
+            return setStandardScale(annualTotal)
+                    .divide(setStandardScale(assessmentCriteria.getApplicantWeightingFactor())
+                                    .add(setStandardScale(assessmentCriteria.getPartnerWeightingFactor()))
                                     .add(totalChildWeighting),
                             RoundingMode.HALF_UP);
         }
@@ -64,5 +65,9 @@ public class InitMeansAssessmentService implements AssessmentService {
         } else {
             return InitAssessmentResult.FULL;
         }
+    }
+
+    private BigDecimal setStandardScale(BigDecimal valueToScale) {
+        return valueToScale.setScale(2, RoundingMode.HALF_UP);
     }
 }

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/InitMeansAssessmentService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/InitMeansAssessmentService.java
@@ -44,7 +44,7 @@ public class InitMeansAssessmentService implements AssessmentService {
                     .divide(assessmentCriteria.getApplicantWeightingFactor()
                                     .add(assessmentCriteria.getPartnerWeightingFactor())
                                     .add(totalChildWeighting),
-                            RoundingMode.UP);
+                            RoundingMode.HALF_UP);
         }
         return BigDecimal.ZERO;
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/InitMeansAssessmentServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/InitMeansAssessmentServiceTest.java
@@ -57,7 +57,8 @@ public class InitMeansAssessmentServiceTest {
         SoftAssertions.assertSoftly(softly -> {
             assertThat(result.getCurrentStatus()).isEqualTo(meansAssessment.getAssessmentStatus());
             assertThat(result.getInitAssessmentResult()).isEqualTo(InitAssessmentResult.FULL);
-            assertThat(result.getAdjustedIncomeValue()).isEqualTo(TestModelDataBuilder.TEST_ADJUSTED_INCOME);
+            assertThat(result.getAdjustedIncomeValue())
+                    .isEqualTo(TestModelDataBuilder.TEST_ADJUSTED_INCOME.setScale(2, RoundingMode.HALF_UP));
             assertThat(result.getTotalAggregatedIncome()).isEqualTo(TestModelDataBuilder.TEST_AGGREGATED_INCOME);
         });
     }
@@ -71,7 +72,8 @@ public class InitMeansAssessmentServiceTest {
         SoftAssertions.assertSoftly(softly -> {
             assertThat(result.getCurrentStatus()).isEqualTo(meansAssessment.getAssessmentStatus());
             assertThat(result.getInitAssessmentResult()).isNull();
-            assertThat(result.getAdjustedIncomeValue()).isEqualTo(TestModelDataBuilder.TEST_ADJUSTED_INCOME);
+            assertThat(result.getAdjustedIncomeValue())
+                    .isEqualTo(TestModelDataBuilder.TEST_ADJUSTED_INCOME.setScale(2, RoundingMode.HALF_UP));
             assertThat(result.getTotalAggregatedIncome()).isEqualTo(TestModelDataBuilder.TEST_AGGREGATED_INCOME);
         });
     }
@@ -110,46 +112,35 @@ public class InitMeansAssessmentServiceTest {
 
     @Test
     public void givenPositiveAnnualTotal_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
-        BigDecimal annualTotal = BigDecimal.valueOf(11000);
-        BigDecimal totalChildWeighting = BigDecimal.valueOf(0.5);
-        BigDecimal combinedWeightingFactor =
-                TestModelDataBuilder.TEST_APPLICANT_WEIGHTING_FACTOR.add(
-                        TestModelDataBuilder.TEST_PARTNER_WEIGHTING_FACTOR
-                ).add(totalChildWeighting);
+        BigDecimal annualTotal = BigDecimal.valueOf(11000.00);
+        BigDecimal totalChildWeighting = BigDecimal.valueOf(0.50);
+        BigDecimal applicantWeightingFactor = TestModelDataBuilder.TEST_APPLICANT_WEIGHTING_FACTOR;
+        BigDecimal partnerWeightingFactor = TestModelDataBuilder.TEST_PARTNER_WEIGHTING_FACTOR;
+        BigDecimal expected = BigDecimal.valueOf(12222.22);
 
-        BigDecimal expected = annualTotal.divide(combinedWeightingFactor, RoundingMode.HALF_UP);
-
-        when(childWeightingService.getTotalChildWeighting(
-                anyList(), any(AssessmentCriteriaEntity.class))
-        ).thenReturn(totalChildWeighting);
-
-        assertThat(initMeansAssessmentService.getAdjustedIncome(
-                TestModelDataBuilder.getMeansAssessmentRequestDTO(true), assessmentCriteria, annualTotal)
-        ).isEqualTo(expected);
+        assertAdjustedIncomeIsCorrect(annualTotal, totalChildWeighting, applicantWeightingFactor, partnerWeightingFactor, expected);
     }
 
     @Test
     public void givenPositiveAnnualTotalRequiringRounding_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
         BigDecimal annualTotal = BigDecimal.valueOf(36613.02);
         BigDecimal totalChildWeighting = BigDecimal.valueOf(0);
-        BigDecimal applicantWeightingFactor = BigDecimal.valueOf(1.00);
+        BigDecimal applicantWeightingFactor = BigDecimal.valueOf(1.0);
         BigDecimal partnerWeightingFactor = BigDecimal.valueOf(0.64);
-
         BigDecimal expected = BigDecimal.valueOf(22325.01);
 
-        AssessmentCriteriaEntity testAssessmentCriteria =
-                AssessmentCriteriaEntity.builder()
-                        .applicantWeightingFactor(applicantWeightingFactor)
-                        .partnerWeightingFactor(partnerWeightingFactor)
-                        .build();
+        assertAdjustedIncomeIsCorrect(annualTotal, totalChildWeighting, applicantWeightingFactor, partnerWeightingFactor, expected);
+    }
 
-        when(childWeightingService.getTotalChildWeighting(
-                anyList(), any(AssessmentCriteriaEntity.class))
-        ).thenReturn(totalChildWeighting);
+    @Test
+    public void givenPositiveAnnualTotalChildWeightingRoundingError_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
+        BigDecimal annualTotal = BigDecimal.valueOf(37506.00);
+        BigDecimal totalChildWeighting = BigDecimal.valueOf(0.68);
+        BigDecimal applicantWeightingFactor = BigDecimal.valueOf(1.00);
+        BigDecimal partnerWeightingFactor = BigDecimal.valueOf(0.64);
+        BigDecimal expected = BigDecimal.valueOf(16166.38);
 
-        assertThat(initMeansAssessmentService.getAdjustedIncome(
-                TestModelDataBuilder.getMeansAssessmentRequestDTO(true), testAssessmentCriteria, annualTotal)
-        ).isEqualTo(expected);
+        assertAdjustedIncomeIsCorrect(annualTotal, totalChildWeighting, applicantWeightingFactor, partnerWeightingFactor, expected);
     }
 
     @Test
@@ -160,6 +151,29 @@ public class InitMeansAssessmentServiceTest {
         ).thenReturn(BigDecimal.ZERO);
         assertThat(initMeansAssessmentService.getAdjustedIncome(
                 TestModelDataBuilder.getMeansAssessmentRequestDTO(true), assessmentCriteria, annualTotal)
-        ).isEqualTo(BigDecimal.ZERO);
+        ).isEqualTo(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
+    }
+
+    private void assertAdjustedIncomeIsCorrect(
+            BigDecimal annualTotal,
+            BigDecimal totalChildWeighting,
+            BigDecimal applicantWeighting,
+            BigDecimal partnerWeighting,
+            BigDecimal expectedValue) {
+
+
+        AssessmentCriteriaEntity testAssessmentCriteria =
+                AssessmentCriteriaEntity.builder()
+                        .applicantWeightingFactor(applicantWeighting)
+                        .partnerWeightingFactor(partnerWeighting)
+                        .build();
+
+        when(childWeightingService.getTotalChildWeighting(
+                anyList(), any(AssessmentCriteriaEntity.class))
+        ).thenReturn(totalChildWeighting);
+
+        assertThat(initMeansAssessmentService.getAdjustedIncome(
+                TestModelDataBuilder.getMeansAssessmentRequestDTO(true), testAssessmentCriteria, annualTotal)
+        ).isEqualTo(expectedValue);
     }
 }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/InitMeansAssessmentServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/InitMeansAssessmentServiceTest.java
@@ -117,7 +117,7 @@ public class InitMeansAssessmentServiceTest {
                         TestModelDataBuilder.TEST_PARTNER_WEIGHTING_FACTOR
                 ).add(totalChildWeighting);
 
-        BigDecimal expected = annualTotal.divide(combinedWeightingFactor, RoundingMode.UP);
+        BigDecimal expected = annualTotal.divide(combinedWeightingFactor, RoundingMode.HALF_UP);
 
         when(childWeightingService.getTotalChildWeighting(
                 anyList(), any(AssessmentCriteriaEntity.class))
@@ -125,6 +125,30 @@ public class InitMeansAssessmentServiceTest {
 
         assertThat(initMeansAssessmentService.getAdjustedIncome(
                 TestModelDataBuilder.getMeansAssessmentRequestDTO(true), assessmentCriteria, annualTotal)
+        ).isEqualTo(expected);
+    }
+
+    @Test
+    public void givenPositiveAnnualTotalRequiringRounding_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
+        BigDecimal annualTotal = BigDecimal.valueOf(36613.02);
+        BigDecimal totalChildWeighting = BigDecimal.valueOf(0);
+        BigDecimal applicantWeightingFactor = BigDecimal.valueOf(1.00);
+        BigDecimal partnerWeightingFactor = BigDecimal.valueOf(0.64);
+
+        BigDecimal expected = BigDecimal.valueOf(22325.01);
+
+        AssessmentCriteriaEntity testAssessmentCriteria =
+                AssessmentCriteriaEntity.builder()
+                        .applicantWeightingFactor(applicantWeightingFactor)
+                        .partnerWeightingFactor(partnerWeightingFactor)
+                        .build();
+
+        when(childWeightingService.getTotalChildWeighting(
+                anyList(), any(AssessmentCriteriaEntity.class))
+        ).thenReturn(totalChildWeighting);
+
+        assertThat(initMeansAssessmentService.getAdjustedIncome(
+                TestModelDataBuilder.getMeansAssessmentRequestDTO(true), testAssessmentCriteria, annualTotal)
         ).isEqualTo(expected);
     }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-121)

- [x] Updated the getAdjustedIncome method in the InitMeansAssessmentService to use HALF-UP rounding instead of UP to fix rounding error on the adjusted income calculation.
- [x] Updated method unit tests

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
