### PR TITLE
LCAM-185

### DIFF
--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilder.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilder.java
@@ -5,27 +5,32 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentDTO;
 import uk.gov.justice.laa.crime.meansassessment.model.common.ApiMeansAssessmentResponse;
+import uk.gov.justice.laa.crime.meansassessment.model.common.MaatApiAssessmentResponse;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.entity.AssessmentCriteriaEntity;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.AssessmentType;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.FullAssessmentResult;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.InitAssessmentResult;
+
+import static java.util.Optional.ofNullable;
 
 @Slf4j
 @Component
 @AllArgsConstructor
 public class MeansAssessmentResponseBuilder {
 
-    public ApiMeansAssessmentResponse build(final Integer financialAssessmentID,
+    public ApiMeansAssessmentResponse build(final MaatApiAssessmentResponse maatApiAssessmentResponse,
                                             final AssessmentCriteriaEntity assessmentCriteria,
                                             final MeansAssessmentDTO completedAssessment) {
 
         ApiMeansAssessmentResponse response = new ApiMeansAssessmentResponse()
-                .withAssessmentId(financialAssessmentID)
+                .withAssessmentId(maatApiAssessmentResponse.getId())
                 .withRepId(completedAssessment.getMeansAssessment().getRepId())
                 .withCriteriaId(assessmentCriteria.getId())
                 .withLowerThreshold(assessmentCriteria.getInitialLowerThreshold())
                 .withUpperThreshold(assessmentCriteria.getInitialUpperThreshold())
                 .withTotalAggregatedIncome(completedAssessment.getTotalAggregatedIncome())
-                .withInitResult(completedAssessment.getInitAssessmentResult().getResult())
-                .withInitResultReason(completedAssessment.getInitAssessmentResult().getReason())
+                .withInitResult(maatApiAssessmentResponse.getInitResult())
+                .withInitResultReason(maatApiAssessmentResponse.getInitResultReason())
                 .withAdjustedIncomeValue(completedAssessment.getAdjustedIncomeValue())
                 .withAssessmentSectionSummary(completedAssessment.getMeansAssessment().getSectionSummaries());
 
@@ -42,7 +47,9 @@ public class MeansAssessmentResponseBuilder {
                 .withTotalAnnualDisposableIncome(completedAssessment.getTotalAnnualDisposableIncome())
                 .withFullThreshold(assessmentCriteria.getFullThreshold())
                 .withTotalAggregatedExpense(completedAssessment.getTotalAggregatedExpense())
-                .withFullResult(completedAssessment.getFullAssessmentResult().getResult())
-                .withFullResultReason(completedAssessment.getFullAssessmentResult().getReason());
+                .withFullResult(ofNullable(completedAssessment.getFullAssessmentResult())
+                        .map(FullAssessmentResult::getResult).orElse(null))
+                .withFullResultReason(ofNullable(completedAssessment.getFullAssessmentResult())
+                        .map(FullAssessmentResult::getReason).orElse(null));
     }
 }

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/MeansAssessmentService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/MeansAssessmentService.java
@@ -66,7 +66,7 @@ public class MeansAssessmentService {
             updateDetailIds(completedAssessment, maatApiAssessmentResponse);
 
             ApiMeansAssessmentResponse assessmentResponse =
-                    responseBuilder.build(maatApiAssessmentResponse.getId(), assessmentCriteria, completedAssessment);
+                    responseBuilder.build(maatApiAssessmentResponse, assessmentCriteria, completedAssessment);
 
             if (AssessmentRequestType.UPDATE.equals(requestType)) {
                 fullAssessmentAvailabilityService.processFullAssessmentAvailable(requestDTO, assessmentResponse);

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilderTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilderTest.java
@@ -1,10 +1,12 @@
 package uk.gov.justice.laa.crime.meansassessment.builder;
 
 import org.assertj.core.api.SoftAssertions;
+import org.junit.Before;
 import org.junit.Test;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentDTO;
 import uk.gov.justice.laa.crime.meansassessment.model.common.ApiMeansAssessmentResponse;
+import uk.gov.justice.laa.crime.meansassessment.model.common.MaatApiAssessmentResponse;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.entity.AssessmentCriteriaEntity;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.AssessmentType;
 
@@ -15,13 +17,21 @@ public class MeansAssessmentResponseBuilderTest {
     private final MeansAssessmentResponseBuilder responseBuilder =
             new MeansAssessmentResponseBuilder();
 
-    private final MeansAssessmentDTO completedAssessment = TestModelDataBuilder.getMeansAssessmentDTO();
-    private final AssessmentCriteriaEntity assessmentCriteria = TestModelDataBuilder.getAssessmentCriteriaEntity();
+    private MeansAssessmentDTO completedAssessment;
+    private final AssessmentCriteriaEntity assessmentCriteria =
+            TestModelDataBuilder.getAssessmentCriteriaEntity();
+    private MaatApiAssessmentResponse maatApiAssessmentResponse;
+
+    @Before
+    public void setup() {
+        completedAssessment = TestModelDataBuilder.getMeansAssessmentDTO();
+        maatApiAssessmentResponse = TestModelDataBuilder.getMaatApiAssessmentResponse();
+    }
 
     private void checkCommonFieldsPopulated(ApiMeansAssessmentResponse response) {
         SoftAssertions.assertSoftly(softly -> {
             assertThat(response.getAssessmentId())
-                    .isEqualTo(TestModelDataBuilder.MEANS_ASSESSMENT_ID);
+                    .isEqualTo(maatApiAssessmentResponse.getId());
             assertThat(response.getRepId())
                     .isEqualTo(completedAssessment.getMeansAssessment().getRepId());
             assertThat(response.getCriteriaId())
@@ -33,9 +43,9 @@ public class MeansAssessmentResponseBuilderTest {
             assertThat(response.getTotalAggregatedIncome())
                     .isEqualTo(completedAssessment.getTotalAggregatedIncome());
             assertThat(response.getInitResult())
-                    .isEqualTo(completedAssessment.getInitAssessmentResult().getResult());
+                    .isEqualTo(maatApiAssessmentResponse.getInitResult());
             assertThat(response.getInitResultReason())
-                    .isEqualTo(completedAssessment.getInitAssessmentResult().getReason());
+                    .isEqualTo(maatApiAssessmentResponse.getInitResultReason());
             assertThat(response.getAdjustedIncomeValue())
                     .isEqualTo(completedAssessment.getAdjustedIncomeValue());
             assertThat(response.getAssessmentSectionSummary())
@@ -46,7 +56,7 @@ public class MeansAssessmentResponseBuilderTest {
     @Test
     public void givenInitAssessmentType_whenBuildIsInvoked_thenCommonFieldsArePopulated() {
         ApiMeansAssessmentResponse response =
-                responseBuilder.build(TestModelDataBuilder.MEANS_ASSESSMENT_ID, assessmentCriteria, completedAssessment);
+                responseBuilder.build(maatApiAssessmentResponse, assessmentCriteria, completedAssessment);
         checkCommonFieldsPopulated(response);
     }
 
@@ -54,7 +64,7 @@ public class MeansAssessmentResponseBuilderTest {
     public void givenFullAssessmentType_whenBuildIsInvoked_thenFullFieldsArePopulated() {
         completedAssessment.getMeansAssessment().setAssessmentType(AssessmentType.FULL);
         ApiMeansAssessmentResponse response =
-                responseBuilder.build(TestModelDataBuilder.MEANS_ASSESSMENT_ID, assessmentCriteria, completedAssessment);
+                responseBuilder.build(maatApiAssessmentResponse, assessmentCriteria, completedAssessment);
 
         checkCommonFieldsPopulated(response);
 

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/data/builder/TestModelDataBuilder.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/data/builder/TestModelDataBuilder.java
@@ -491,6 +491,8 @@ public class TestModelDataBuilder {
 
     public static MaatApiAssessmentResponse getMaatApiAssessmentResponse() {
         return new MaatApiAssessmentResponse()
+                .withInitResult("PASS")
+                .withInitResultReason("Gross income below the lower threshold")
                 .withAssessmentDetails(getApiAssessmentDetails());
     }
 }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/MeansAssessmentServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/MeansAssessmentServiceTest.java
@@ -283,7 +283,7 @@ public class MeansAssessmentServiceTest {
                 any(BigDecimal.class), any(MeansAssessmentRequestDTO.class), any(AssessmentCriteriaEntity.class)
         );
         verify(meansAssessmentResponseBuilder).build(
-                anyInt(), any(AssessmentCriteriaEntity.class), any(MeansAssessmentDTO.class)
+                any(MaatApiAssessmentResponse.class), any(AssessmentCriteriaEntity.class), any(MeansAssessmentDTO.class)
         );
     }
 
@@ -299,7 +299,7 @@ public class MeansAssessmentServiceTest {
         );
         verify(fullAssessmentAvailabilityService).processFullAssessmentAvailable(meansAssessment, result);
         verify(meansAssessmentResponseBuilder).build(
-                anyInt(), any(AssessmentCriteriaEntity.class), any(MeansAssessmentDTO.class)
+                any(MaatApiAssessmentResponse.class), any(AssessmentCriteriaEntity.class), any(MeansAssessmentDTO.class)
         );
     }
 


### PR DESCRIPTION
[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-185)

- Refactored MeansAssessmentResponseBuilder to prevent bug causing NullPointerException. The build method now ingests the response from MaatAPI rather than the assessment object.
