### PR TITLE
LCAM-196

### DIFF
--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MaatCourtDataAssessmentBuilder.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MaatCourtDataAssessmentBuilder.java
@@ -97,6 +97,7 @@ public class MaatCourtDataAssessmentBuilder {
                 .withFullTotalAnnualDisposableIncome(assessment.getTotalAnnualDisposableIncome())
                 .withFullOtherHousingNote(meansAssessment.getOtherHousingNote())
                 .withFullTotalAggregatedExpenses(assessment.getTotalAggregatedExpense())
-                .withUserModified(meansAssessment.getUserSession().getUserName());
+                .withUserModified(meansAssessment.getUserSession().getUserName())
+                .withFinancialAssessmentId(meansAssessment.getFinancialAssessmentId());
     }
 }

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/exception/RestControllerAdviser.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/exception/RestControllerAdviser.java
@@ -17,7 +17,7 @@ public class RestControllerAdviser {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseEntity<ErrorDTO> adviceBadRequests(MethodArgumentNotValidException ex) {
-        log.error(" EA Bad request is passed in: ", ex);
+        log.error("Bad request is passed in: ", ex);
         return getNewErrorResponseWith(HttpStatus.BAD_REQUEST, String.valueOf(ex.getBindingResult()));
     }
 

--- a/crime-means-assessment/src/main/resources/application.yaml
+++ b/crime-means-assessment/src/main/resources/application.yaml
@@ -29,8 +29,8 @@ maatApi:
     outstanding-assessments-url: ${maatApi.assessments-domain}/financial-assessments/check-outstanding/{repId}
   financial-assessment-endpoints:
     create-url: ${maatApi.assessments-domain}/financial-assessments/
+    update-url: ${maatApi.assessments-domain}/financial-assessments/
     search-url: ${maatApi.assessments-domain}/financial-assessments/{financialAssessmentId}
-    update-url: ${maatApi.assessments-domain}/financial-assessments/{financialAssessmentId}
   passport-assessment-endpoints:
     find-url: ${maatApi.assessments-domain}/passport-assessments/repId/{repId}
   hardship-review-endpoints:

--- a/crime-means-assessment/src/main/resources/schemas/apiUpdateMeansAssessmentRequest.json
+++ b/crime-means-assessment/src/main/resources/schemas/apiUpdateMeansAssessmentRequest.json
@@ -31,5 +31,5 @@
     "$ref": "apiMeansAssessmentRequest.json"
   },
   "additionalProperties": false,
-  "required": ["fullAssessmentDate", "initTotalAggregatedIncome"]
+  "required": ["initTotalAggregatedIncome"]
 }

--- a/crime-means-assessment/src/main/resources/schemas/maatApiUpdateAssessment.json
+++ b/crime-means-assessment/src/main/resources/schemas/maatApiUpdateAssessment.json
@@ -60,7 +60,5 @@
     "$ref": "maatApiAssessmentRequest.json"
   },
   "additionalProperties": false,
-  "required": [
-    "userModified"
-  ]
+  "required": ["userModified"]
 }

--- a/crime-means-assessment/src/main/resources/schemas/maatApiUpdateAssessment.json
+++ b/crime-means-assessment/src/main/resources/schemas/maatApiUpdateAssessment.json
@@ -49,6 +49,10 @@
     "userModified": {
       "type": "string",
       "description": "ID of the user that last modified the assessment"
+    },
+    "financialAssessmentId": {
+      "type": "integer",
+      "description": "Financial assessment ID"
     }
   },
   "extends": {

--- a/crime-means-assessment/src/main/resources/schemas/maatApiUpdateAssessment.json
+++ b/crime-means-assessment/src/main/resources/schemas/maatApiUpdateAssessment.json
@@ -50,9 +50,10 @@
       "type": "string",
       "description": "ID of the user that last modified the assessment"
     },
-    "financialAssessmentId": {
+    "id": {
       "type": "integer",
-      "description": "Financial assessment ID"
+      "description": "Financial assessment ID",
+      "javaName": "financialAssessmentId"
     }
   },
   "extends": {

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MaatCourtDataAssessmentBuilderTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MaatCourtDataAssessmentBuilderTest.java
@@ -68,15 +68,7 @@ public class MaatCourtDataAssessmentBuilderTest {
         });
     }
 
-    @Test
-    public void givenCreateRequestType_whenBuildAssessmentRequestIsInvoked_thenCreateFieldsArePopulated() {
-        MaatApiAssessmentRequest resultDto =
-                requestDTOBuilder.build(assessmentDTO, AssessmentRequestType.CREATE);
-
-        checkCommonFields(resultDto);
-        assertThat(resultDto.getChildWeightings())
-                .isEqualTo(assessmentDTO.getMeansAssessment().getChildWeightings());
-
+    private void checkCreateFields(MaatApiAssessmentRequest resultDto) {
         Consumer<MaatApiCreateAssessment> createRequirements = createRequest -> {
             assertThat(createRequest.getUsn())
                     .isEqualTo(assessmentDTO.getMeansAssessment().getUsn());
@@ -95,15 +87,7 @@ public class MaatCourtDataAssessmentBuilderTest {
         assertThat(resultDto).isInstanceOfSatisfying(MaatApiCreateAssessment.class, createRequirements);
     }
 
-    @Test
-    public void givenUpdateRequestType_whenBuildAssessmentRequestIsInvoked_thenUpdateFieldsArePopulated() {
-        MaatApiAssessmentRequest resultDto =
-                requestDTOBuilder.build(assessmentDTO, AssessmentRequestType.UPDATE);
-
-        checkCommonFields(resultDto);
-        assertThat(resultDto.getChildWeightings())
-                .isEqualTo(assessmentDTO.getMeansAssessment().getChildWeightings());
-
+    private void checkUpdateFields(MaatApiAssessmentRequest resultDto) {
         Consumer<MaatApiUpdateAssessment> updateRequirements = updateRequest -> {
             assertThat(updateRequest.getFullAscrId())
                     .isEqualTo(assessmentDTO.getAssessmentCriteria().getId());
@@ -128,6 +112,28 @@ public class MaatCourtDataAssessmentBuilderTest {
         };
 
         assertThat(resultDto).isInstanceOfSatisfying(MaatApiUpdateAssessment.class, updateRequirements);
+    }
+
+    @Test
+    public void givenCreateRequestType_whenBuildAssessmentRequestIsInvoked_thenCreateFieldsArePopulated() {
+        MaatApiAssessmentRequest resultDto =
+                requestDTOBuilder.build(assessmentDTO, AssessmentRequestType.CREATE);
+
+        checkCommonFields(resultDto);
+        checkCreateFields(resultDto);
+        assertThat(resultDto.getChildWeightings())
+                .isEqualTo(assessmentDTO.getMeansAssessment().getChildWeightings());
+    }
+
+    @Test
+    public void givenUpdateRequestType_whenBuildAssessmentRequestIsInvoked_thenUpdateFieldsArePopulated() {
+        MaatApiAssessmentRequest resultDto =
+                requestDTOBuilder.build(assessmentDTO, AssessmentRequestType.UPDATE);
+
+        checkCommonFields(resultDto);
+        checkUpdateFields(resultDto);
+        assertThat(resultDto.getChildWeightings())
+                .isEqualTo(assessmentDTO.getMeansAssessment().getChildWeightings());
     }
 
     @Test
@@ -137,25 +143,9 @@ public class MaatCourtDataAssessmentBuilderTest {
                 requestDTOBuilder.build(assessmentDTO, AssessmentRequestType.CREATE);
 
         checkCommonFields(resultDto);
+        checkCreateFields(resultDto);
         assertThat(resultDto.getChildWeightings())
                 .isNotEqualTo(assessmentDTO.getMeansAssessment().getChildWeightings());
-
-        Consumer<MaatApiCreateAssessment> createRequirements = createRequest -> {
-            assertThat(createRequest.getUsn())
-                    .isEqualTo(assessmentDTO.getMeansAssessment().getUsn());
-            assertThat(createRequest.getRtCode())
-                    .isEqualTo(assessmentDTO.getMeansAssessment().getReviewType().getCode());
-            assertThat(createRequest.getNworCode())
-                    .isEqualTo(assessmentDTO.getMeansAssessment().getNewWorkReason().getCode());
-            assertThat(createRequest.getUserCreated())
-                    .isEqualTo(assessmentDTO.getMeansAssessment().getUserSession().getUserName());
-            assertThat(createRequest.getIncomeUpliftRemoveDate())
-                    .isEqualTo(assessmentDTO.getMeansAssessment().getIncomeEvidenceSummary().getUpliftRemovedDate());
-            assertThat(createRequest.getIncomeUpliftApplyDate())
-                    .isEqualTo(assessmentDTO.getMeansAssessment().getIncomeEvidenceSummary().getUpliftAppliedDate());
-        };
-
-        assertThat(resultDto).isInstanceOfSatisfying(MaatApiCreateAssessment.class, createRequirements);
     }
 
     @Test
@@ -165,32 +155,8 @@ public class MaatCourtDataAssessmentBuilderTest {
                 requestDTOBuilder.build(assessmentDTO, AssessmentRequestType.UPDATE);
 
         checkCommonFields(resultDto);
+        checkUpdateFields(resultDto);
         assertThat(resultDto.getChildWeightings())
                 .isNotEqualTo(assessmentDTO.getMeansAssessment().getChildWeightings());
-
-        Consumer<MaatApiUpdateAssessment> updateRequirements = updateRequest -> {
-            assertThat(updateRequest.getFullAscrId())
-                    .isEqualTo(assessmentDTO.getAssessmentCriteria().getId());
-            assertThat(updateRequest.getFullAssessmentDate())
-                    .isEqualTo(assessmentDTO.getMeansAssessment().getFullAssessmentDate());
-            assertThat(updateRequest.getFullResult())
-                    .isEqualTo(assessmentDTO.getFullAssessmentResult().getResult());
-            assertThat(updateRequest.getFullResultReason())
-                    .isEqualTo(assessmentDTO.getFullAssessmentResult().getReason());
-            assertThat(updateRequest.getFullAssessmentNotes())
-                    .isEqualTo(assessmentDTO.getMeansAssessment().getFullAssessmentNotes());
-            assertThat(updateRequest.getFullAdjustedLivingAllowance())
-                    .isEqualTo(assessmentDTO.getAdjustedLivingAllowance());
-            assertThat(updateRequest.getFullTotalAnnualDisposableIncome())
-                    .isEqualTo(assessmentDTO.getTotalAnnualDisposableIncome());
-            assertThat(updateRequest.getFullOtherHousingNote())
-                    .isEqualTo(assessmentDTO.getMeansAssessment().getOtherHousingNote());
-            assertThat(updateRequest.getFullTotalAggregatedExpenses())
-                    .isEqualTo(assessmentDTO.getTotalAggregatedExpense());
-            assertThat(updateRequest.getUserModified())
-                    .isEqualTo(assessmentDTO.getMeansAssessment().getUserSession().getUserName());
-        };
-
-        assertThat(resultDto).isInstanceOfSatisfying(MaatApiUpdateAssessment.class, updateRequirements);
     }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-196)

- Fixed incorrect Court Data API URL for updating financial assessments.
- The financial assessment id is now included in update requests, this is a required field.
- Removed redundant schema validation that is now being done in a dedicated validator class.
