### PR TITLE
LCAM-242

### DIFF
--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentRequestDTOBuilder.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentRequestDTOBuilder.java
@@ -3,7 +3,9 @@ package uk.gov.justice.laa.crime.meansassessment.builder;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
-import uk.gov.justice.laa.crime.meansassessment.model.common.*;
+import uk.gov.justice.laa.crime.meansassessment.model.common.ApiCreateMeansAssessmentRequest;
+import uk.gov.justice.laa.crime.meansassessment.model.common.ApiMeansAssessmentRequest;
+import uk.gov.justice.laa.crime.meansassessment.model.common.ApiUpdateMeansAssessmentRequest;
 
 @Component
 @AllArgsConstructor
@@ -31,13 +33,13 @@ public class MeansAssessmentRequestDTOBuilder {
                 .incomeEvidenceSummary(assessmentRequest.getIncomeEvidenceSummary())
                 .crownCourtOverview(assessmentRequest.getCrownCourtOverview())
                 .magCourtOutcome(assessmentRequest.getMagCourtOutcome())
+                .newWorkReason(assessmentRequest.getNewWorkReason())
                 .build();
 
         if (assessmentRequest instanceof ApiCreateMeansAssessmentRequest) {
             ApiCreateMeansAssessmentRequest initMeansAssessmentRequest = (ApiCreateMeansAssessmentRequest) assessmentRequest;
             requestDTO.setUsn(initMeansAssessmentRequest.getUsn());
             requestDTO.setReviewType(initMeansAssessmentRequest.getReviewType());
-            requestDTO.setNewWorkReason(initMeansAssessmentRequest.getNewWorkReason());
         }
 
         if (assessmentRequest instanceof ApiUpdateMeansAssessmentRequest) {

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaService.java
@@ -81,13 +81,13 @@ public class AssessmentCriteriaService {
                     || detail.getApplicantAmount().compareTo(BigDecimal.ZERO) != 0) {
                 if ((criteriaDetailValue.getApplicantValue().compareTo(detail.getApplicantAmount()) != 0 ||
                         (applicantFrequency != null &&
-                                applicantFrequency.getCode().equals(
+                                !applicantFrequency.getCode().equals(
                                         criteriaDetailValue.getApplicantFrequency().getCode()
                                 )
                         )) ||
                         (criteriaDetailValue.getPartnerValue().compareTo(detail.getPartnerAmount()) != 0 ||
                                 (partnerFrequency != null &&
-                                        partnerFrequency.getCode().equals(
+                                        !partnerFrequency.getCode().equals(
                                                 criteriaDetailValue.getPartnerFrequency().getCode()
                                         )
                                 )

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaService.java
@@ -77,8 +77,8 @@ public class AssessmentCriteriaService {
                 ).orElse(null);
 
         if (criteriaDetailValue != null) {
-            if (detail.getPartnerAmount().compareTo(BigDecimal.ZERO) != 0
-                    || detail.getApplicantAmount().compareTo(BigDecimal.ZERO) != 0) {
+            if (BigDecimal.ZERO.compareTo(detail.getPartnerAmount()) != 0
+                    || BigDecimal.ZERO.compareTo(detail.getApplicantAmount()) != 0) {
                 if ((criteriaDetailValue.getApplicantValue().compareTo(detail.getApplicantAmount()) != 0 ||
                         (applicantFrequency != null &&
                                 !applicantFrequency.getCode().equals(

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaService.java
@@ -76,25 +76,17 @@ public class AssessmentCriteriaService {
                         criteriaDetail, caseType
                 ).orElse(null);
 
-        if (criteriaDetailValue != null) {
-            if (BigDecimal.ZERO.compareTo(detail.getPartnerAmount()) != 0
-                    || BigDecimal.ZERO.compareTo(detail.getApplicantAmount()) != 0) {
-                if ((criteriaDetailValue.getApplicantValue().compareTo(detail.getApplicantAmount()) != 0 ||
+        if (criteriaDetailValue != null &&
+                ((criteriaDetailValue.getApplicantValue().compareTo(detail.getApplicantAmount()) != 0 ||
                         (applicantFrequency != null &&
-                                !applicantFrequency.getCode().equals(
-                                        criteriaDetailValue.getApplicantFrequency().getCode()
-                                )
+                                !applicantFrequency.getCode().equals(criteriaDetailValue.getApplicantFrequency().getCode())
                         )) ||
                         (criteriaDetailValue.getPartnerValue().compareTo(detail.getPartnerAmount()) != 0 ||
                                 (partnerFrequency != null &&
-                                        !partnerFrequency.getCode().equals(
-                                                criteriaDetailValue.getPartnerFrequency().getCode()
-                                        )
+                                        !partnerFrequency.getCode().equals(criteriaDetailValue.getPartnerFrequency().getCode())
                                 )
-                        )) {
-                    throw new ValidationException("Incorrect amount entered for: " + criteriaDetail.getDescription());
-                }
-            }
+                        ))) {
+            throw new ValidationException("Incorrect amount entered for: " + criteriaDetail.getDescription());
         }
     }
 

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaService.java
@@ -76,15 +76,26 @@ public class AssessmentCriteriaService {
                         criteriaDetail, caseType
                 ).orElse(null);
 
-        if (criteriaDetailValue != null && (!criteriaDetailValue.getApplicantValue().equals(detail.getApplicantAmount()) ||
-                !criteriaDetailValue.getApplicantFrequency().getCode().equals(
-                        Optional.ofNullable(applicantFrequency).map(Frequency::getCode).orElse(null)) ||
-                !criteriaDetailValue.getPartnerValue().equals(detail.getPartnerAmount()) ||
-                !criteriaDetailValue.getPartnerFrequency().getCode().equals(
-                        Optional.ofNullable(partnerFrequency).map(Frequency::getCode).orElse(null)))) {
-            throw new ValidationException("Incorrect amount entered for: " + criteriaDetail.getDescription());
+        if (criteriaDetailValue != null) {
+            if (detail.getPartnerAmount().compareTo(BigDecimal.ZERO) != 0
+                    || detail.getApplicantAmount().compareTo(BigDecimal.ZERO) != 0) {
+                if ((criteriaDetailValue.getApplicantValue().compareTo(detail.getApplicantAmount()) != 0 ||
+                        (applicantFrequency != null &&
+                                applicantFrequency.getCode().equals(
+                                        criteriaDetailValue.getApplicantFrequency().getCode()
+                                )
+                        )) ||
+                        (criteriaDetailValue.getPartnerValue().compareTo(detail.getPartnerAmount()) != 0 ||
+                                (partnerFrequency != null &&
+                                        partnerFrequency.getCode().equals(
+                                                criteriaDetailValue.getPartnerFrequency().getCode()
+                                        )
+                                )
+                        )) {
+                    throw new ValidationException("Incorrect amount entered for: " + criteriaDetail.getDescription());
+                }
+            }
         }
-
     }
 
     public Optional<AssessmentCriteriaChildWeightingEntity> getAssessmentCriteriaChildWeightingsById(Integer id) {

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/MeansAssessmentValidationProcessor.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/MeansAssessmentValidationProcessor.java
@@ -42,10 +42,9 @@ public class MeansAssessmentValidationProcessor {
             throw new ValidationException(MSG_RECORD_NOT_RESERVED_BY_CURRENT_USER);
         }
 
-        if (AssessmentRequestType.CREATE.equals(requestType)) {
-            if (meansAssessmentValidationService.isOutstandingAssessment(requestDTO)) {
-                throw new ValidationException(MSG_INCOMPLETE_ASSESSMENT_FOUND);
-            }
+        if (AssessmentRequestType.CREATE.equals(requestType) &&
+                meansAssessmentValidationService.isOutstandingAssessment(requestDTO)) {
+            throw new ValidationException(MSG_INCOMPLETE_ASSESSMENT_FOUND);
         }
 
         if (AssessmentType.INIT.equals(requestDTO.getAssessmentType())) {

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/MeansAssessmentValidationProcessor.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/MeansAssessmentValidationProcessor.java
@@ -43,15 +43,15 @@ public class MeansAssessmentValidationProcessor {
         }
 
         if (AssessmentRequestType.CREATE.equals(requestType)) {
-            if (!meansAssessmentValidationService.isNewWorkReasonValid(requestDTO)) {
-                throw new ValidationException(MSG_NEW_WORK_REASON_IS_NOT_VALID);
-            } else if (meansAssessmentValidationService.isOutstandingAssessment(requestDTO)) {
+            if (meansAssessmentValidationService.isOutstandingAssessment(requestDTO)) {
                 throw new ValidationException(MSG_INCOMPLETE_ASSESSMENT_FOUND);
             }
         }
 
         if (AssessmentType.INIT.equals(requestDTO.getAssessmentType())) {
-            if (!initAssessmentValidator.validate(requestDTO)) {
+            if (!meansAssessmentValidationService.isNewWorkReasonValid(requestDTO)) {
+                throw new ValidationException(MSG_NEW_WORK_REASON_IS_NOT_VALID);
+            } else if (!initAssessmentValidator.validate(requestDTO)) {
                 throw new ValidationException(MSG_INCORRECT_REVIEW_TYPE);
             }
         } else {

--- a/crime-means-assessment/src/main/resources/schemas/apiCreateMeansAssessmentRequest.json
+++ b/crime-means-assessment/src/main/resources/schemas/apiCreateMeansAssessmentRequest.json
@@ -5,10 +5,6 @@
   "title": "Initial Means Assessment Request",
   "description": "Data contract for initial means assessment requests",
   "properties": {
-    "newWorkReason": {
-      "description": "Work Reason Details",
-      "existingJavaType": "uk.gov.justice.laa.crime.meansassessment.staticdata.enums.NewWorkReason"
-    },
     "reviewType": {
       "description": "Review Type Info",
       "existingJavaType": "uk.gov.justice.laa.crime.meansassessment.staticdata.enums.ReviewType"
@@ -21,6 +17,5 @@
   "extends": {
     "$ref": "apiMeansAssessmentRequest.json"
   },
-  "additionalProperties": false,
-  "required": ["newWorkReason"]
+  "additionalProperties": false
 }

--- a/crime-means-assessment/src/main/resources/schemas/apiMeansAssessmentRequest.json
+++ b/crime-means-assessment/src/main/resources/schemas/apiMeansAssessmentRequest.json
@@ -94,6 +94,10 @@
       "type": "object",
       "description": "Magistrate Court Outcome",
       "existingJavaType": "uk.gov.justice.laa.crime.meansassessment.staticdata.enums.MagCourtOutcome"
+    },
+    "newWorkReason": {
+      "description": "Work Reason Details",
+      "existingJavaType": "uk.gov.justice.laa.crime.meansassessment.staticdata.enums.NewWorkReason"
     }
   },
   "additionalProperties": false,

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaServiceTest.java
@@ -15,6 +15,7 @@ import uk.gov.justice.laa.crime.meansassessment.exception.ValidationException;
 import uk.gov.justice.laa.crime.meansassessment.model.common.ApiAssessmentDetail;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.entity.AssessmentCriteriaDetailEntity;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.entity.AssessmentCriteriaEntity;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.entity.CaseTypeAssessmentCriteriaDetailValueEntity;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.CaseType;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.Frequency;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.repository.AssessmentCriteriaDetailFrequencyRepository;
@@ -25,10 +26,9 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AssessmentCriteriaServiceTest {
@@ -119,7 +119,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenValidFrequency_whenCheckFrequencyIsInvoked_thenDoesNothing() {
+    public void givenValidFrequency_whenCheckCriteriaDetailFrequencyIsInvoked_thenDoesNothing() {
         when(assessmentCriteriaDetailFrequencyRepository.findByAssessmentCriteriaDetailAndFrequency(
                         any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
                 )
@@ -129,7 +129,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenInvalidFrequency_whenCheckFrequencyIsInvoked_thenExceptionIsThrown() {
+    public void givenInvalidFrequency_whenCheckCriteriaDetailFrequencyIsInvoked_thenExceptionIsThrown() {
         when(assessmentCriteriaDetailFrequencyRepository.findByAssessmentCriteriaDetailAndFrequency(
                         any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
                 )
@@ -182,12 +182,13 @@ public class AssessmentCriteriaServiceTest {
     public void givenApplicantFrequency_whenCheckAssessmentDetailIsInvoked_thenValidateApplicantFrequency() {
         String section = TestModelDataBuilder.TEST_SECTION;
         ApiAssessmentDetail detail = TestModelDataBuilder.getApiAssessmentDetails().get(0);
-        doNothing().when(assessmentCriteriaService)
-                .checkCriteriaDetailFrequency(any(AssessmentCriteriaDetailEntity.class), any(Frequency.class));
+
+        when(assessmentCriteriaDetailFrequencyRepository.findByAssessmentCriteriaDetailAndFrequency(
+                        any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
+                )
+        ).thenReturn(Optional.of(TestModelDataBuilder.getAssessmentCriteriaDetailFrequencyEntity()));
+
         assessmentCriteriaService.checkAssessmentDetail(CaseType.EITHER_WAY, section, assessmentCriteriaEntity, detail);
-        verify(assessmentCriteriaService).checkCriteriaDetailFrequency(
-                any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
-        );
     }
 
     @Test
@@ -196,14 +197,12 @@ public class AssessmentCriteriaServiceTest {
         ApiAssessmentDetail detail = TestModelDataBuilder.getApiAssessmentDetails(true).get(0);
 
         detail.setApplicantFrequency(null);
+        when(assessmentCriteriaDetailFrequencyRepository.findByAssessmentCriteriaDetailAndFrequency(
+                        any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
+                )
+        ).thenReturn(Optional.of(TestModelDataBuilder.getAssessmentCriteriaDetailFrequencyEntity()));
 
-        doNothing().when(assessmentCriteriaService).checkCriteriaDetailFrequency(
-                any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
-        );
         assessmentCriteriaService.checkAssessmentDetail(CaseType.EITHER_WAY, section, assessmentCriteriaEntity, detail);
-        verify(assessmentCriteriaService).checkCriteriaDetailFrequency(
-                any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
-        );
     }
 
     @Test
@@ -215,14 +214,12 @@ public class AssessmentCriteriaServiceTest {
                 any(AssessmentCriteriaDetailEntity.class), any(CaseType.class))
         ).thenReturn(Optional.empty());
 
-        doNothing().when(assessmentCriteriaService).checkCriteriaDetailFrequency(
-                any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
-        );
+        when(assessmentCriteriaDetailFrequencyRepository.findByAssessmentCriteriaDetailAndFrequency(
+                        any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
+                )
+        ).thenReturn(Optional.of(TestModelDataBuilder.getAssessmentCriteriaDetailFrequencyEntity()));
 
         assessmentCriteriaService.checkAssessmentDetail(CaseType.EITHER_WAY, section, assessmentCriteriaEntity, detail);
-        verify(caseTypeAssessmentCriteriaDetailValueRepository).findByAssessmentCriteriaDetailAndCaseType(
-                any(AssessmentCriteriaDetailEntity.class), any(CaseType.class)
-        );
     }
 
     @Test
@@ -234,14 +231,12 @@ public class AssessmentCriteriaServiceTest {
                 any(AssessmentCriteriaDetailEntity.class), any(CaseType.class))
         ).thenReturn(Optional.of(TestModelDataBuilder.getCaseTypeAssessmentCriteriaDetailValueEntity()));
 
-        doNothing().when(assessmentCriteriaService).checkCriteriaDetailFrequency(
-                any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
-        );
+        when(assessmentCriteriaDetailFrequencyRepository.findByAssessmentCriteriaDetailAndFrequency(
+                        any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
+                )
+        ).thenReturn(Optional.of(TestModelDataBuilder.getAssessmentCriteriaDetailFrequencyEntity()));
 
         assessmentCriteriaService.checkAssessmentDetail(CaseType.EITHER_WAY, section, assessmentCriteriaEntity, detail);
-        verify(caseTypeAssessmentCriteriaDetailValueRepository).findByAssessmentCriteriaDetailAndCaseType(
-                any(AssessmentCriteriaDetailEntity.class), any(CaseType.class)
-        );
     }
 
     @Test
@@ -249,22 +244,30 @@ public class AssessmentCriteriaServiceTest {
         String section = TestModelDataBuilder.TEST_SECTION;
         ApiAssessmentDetail detail = TestModelDataBuilder.getApiAssessmentDetails(true).get(0);
 
+        CaseTypeAssessmentCriteriaDetailValueEntity criteriaDetailValueEntity =
+                TestModelDataBuilder.getCaseTypeAssessmentCriteriaDetailValueEntity();
         when(caseTypeAssessmentCriteriaDetailValueRepository.findByAssessmentCriteriaDetailAndCaseType(
                 any(AssessmentCriteriaDetailEntity.class), any(CaseType.class))
-        ).thenReturn(Optional.of(TestModelDataBuilder.getCaseTypeAssessmentCriteriaDetailValueEntity()));
+        ).thenReturn(Optional.of(criteriaDetailValueEntity));
 
-        doNothing().when(assessmentCriteriaService).checkCriteriaDetailFrequency(
-                any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
-        );
+        when(assessmentCriteriaDetailFrequencyRepository.findByAssessmentCriteriaDetailAndFrequency(
+                        any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
+                )
+        ).thenReturn(Optional.of(TestModelDataBuilder.getAssessmentCriteriaDetailFrequencyEntity()));
 
         String expectedErrorMessage = "Incorrect amount entered for: " + TestModelDataBuilder.TEST_DESCRIPTION;
         ThrowableAssert.ThrowingCallable function =
                 () -> assessmentCriteriaService.checkAssessmentDetail(CaseType.EITHER_WAY, section, assessmentCriteriaEntity, detail);
 
         SoftAssertions.assertSoftly(softly -> {
+
             detail.setApplicantAmount(BigDecimal.ZERO);
             assertThatThrownBy(function).isInstanceOf(ValidationException.class).hasMessageContaining(expectedErrorMessage);
             detail.setApplicantAmount(TestModelDataBuilder.TEST_APPLICANT_VALUE);
+
+            detail.setApplicantFrequency(null);
+            assertThatNoException().isThrownBy(function);
+            detail.setApplicantFrequency(TestModelDataBuilder.TEST_FREQUENCY);
 
             detail.setApplicantFrequency(Frequency.FOUR_WEEKLY);
             assertThatThrownBy(function).isInstanceOf(ValidationException.class).hasMessageContaining(expectedErrorMessage);
@@ -273,6 +276,10 @@ public class AssessmentCriteriaServiceTest {
             detail.setPartnerAmount(BigDecimal.ZERO);
             assertThatThrownBy(function).isInstanceOf(ValidationException.class).hasMessageContaining(expectedErrorMessage);
             detail.setPartnerAmount(TestModelDataBuilder.TEST_PARTNER_VALUE);
+
+            detail.setPartnerFrequency(null);
+            assertThatNoException().isThrownBy(function);
+            detail.setPartnerFrequency(TestModelDataBuilder.TEST_FREQUENCY);
 
             detail.setPartnerFrequency(Frequency.FOUR_WEEKLY);
             assertThatThrownBy(function).isInstanceOf(ValidationException.class).hasMessageContaining(expectedErrorMessage);

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaServiceTest.java
@@ -25,8 +25,8 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -56,75 +56,89 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenAssessmentCriteriaIsPopulated_WhenValidDateWithPartnerAndNoContraryInterestIsProvided_ThenAssessmentCriteriaShouldBeReturnedWithPartnerWeightingFactor() {
-        // given Assessment Criteria is populated and matching results are returned
-        when(assessmentCriteriaRepository.findAssessmentCriteriaForDate(any(LocalDateTime.class))).thenReturn(assessmentCriteriaEntity);
-        // when Assessment Criteria valid after a certain time are requested
-        AssessmentCriteriaEntity result = assessmentCriteriaService.getAssessmentCriteria(TestModelDataBuilder.TEST_DATE_FROM.plusHours(1), true, false);
-        // then expected Assessment Criteria are returned
-        assertEquals(assessmentCriteriaEntity.getPartnerWeightingFactor(), result.getPartnerWeightingFactor());
+    public void givenValidDateWithPartnerAndNoContraryInterest_WhenGetAssessmentCriteriaIsInvoked_ThenAssessmentCriteriaShouldBeReturnedWithPartnerWeightingFactor() {
+        when(assessmentCriteriaRepository.findAssessmentCriteriaForDate(any(LocalDateTime.class)))
+                .thenReturn(assessmentCriteriaEntity);
+
+        AssessmentCriteriaEntity result =
+                assessmentCriteriaService.getAssessmentCriteria(
+                        TestModelDataBuilder.TEST_DATE_FROM.plusHours(1), true, false
+                );
+        assertThat(assessmentCriteriaEntity.getPartnerWeightingFactor()).isEqualTo(result.getPartnerWeightingFactor());
     }
 
     @Test
-    public void givenAssessmentCriteriaIsPopulated_WhenValidDateAndNoPartnerIsProvided_ThenAssessmentCriteriaShouldBeReturnedWithZeroedPartnerWeightingFactor() {
-        // given Assessment Criteria is populated and matching results are returned
-        when(assessmentCriteriaRepository.findAssessmentCriteriaForDate(any(LocalDateTime.class))).thenReturn(assessmentCriteriaEntity);
-        // when Assessment Criteria valid after a certain time are requested
-        AssessmentCriteriaEntity result = assessmentCriteriaService.getAssessmentCriteria(TestModelDataBuilder.TEST_DATE_FROM.plusHours(1), false, false);
-        // then expected Assessment Criteria are returned
-        assertEquals(assessmentCriteriaEntity, result);
-        assertEquals(BigDecimal.ZERO, result.getPartnerWeightingFactor());
+    public void givenValidDateAndNoPartner_WhenGetAssessmentCriteriaIsInvoked_ThenAssessmentCriteriaShouldBeReturnedWithZeroedPartnerWeightingFactor() {
+        when(assessmentCriteriaRepository.findAssessmentCriteriaForDate(any(LocalDateTime.class)))
+                .thenReturn(assessmentCriteriaEntity);
+
+        AssessmentCriteriaEntity result =
+                assessmentCriteriaService.getAssessmentCriteria(
+                        TestModelDataBuilder.TEST_DATE_FROM.plusHours(1), false, false
+                );
+        assertThat(assessmentCriteriaEntity).isEqualTo(result);
+        assertThat(BigDecimal.ZERO).isEqualTo(result.getPartnerWeightingFactor());
     }
 
     @Test
-    public void givenAssessmentCriteriaIsPopulated_WhenValidDateWithPartnerAndContraryInterestIsProvided_ThenAssessmentCriteriaShouldBeReturnedWithPartnerWeightingFactor() {
-        // given Assessment Criteria is populated and matching results are returned
-        when(assessmentCriteriaRepository.findAssessmentCriteriaForDate(any(LocalDateTime.class))).thenReturn(assessmentCriteriaEntity);
-        // when Assessment Criteria valid after a certain time are requested
-        AssessmentCriteriaEntity result = assessmentCriteriaService.getAssessmentCriteria(TestModelDataBuilder.TEST_DATE_FROM.plusHours(1), true, true);
-        // then expected Assessment Criteria are returned
-        assertEquals(assessmentCriteriaEntity, result);
-        assertEquals(result.getPartnerWeightingFactor(), assessmentCriteriaEntity.getPartnerWeightingFactor());
+    public void givenValidDateWithPartnerAndContraryInterest_WhenGetAssessmentCriteriaIsInvoked_ThenAssessmentCriteriaShouldBeReturnedWithPartnerWeightingFactor() {
+        when(assessmentCriteriaRepository.findAssessmentCriteriaForDate(any(LocalDateTime.class)))
+                .thenReturn(assessmentCriteriaEntity);
+
+        AssessmentCriteriaEntity result =
+                assessmentCriteriaService.getAssessmentCriteria(
+                        TestModelDataBuilder.TEST_DATE_FROM.plusHours(1), true, true
+                );
+        assertThat(assessmentCriteriaEntity).isEqualTo(result);
+        assertThat(result.getPartnerWeightingFactor()).isEqualTo(assessmentCriteriaEntity.getPartnerWeightingFactor());
     }
 
     @Test
-    public void givenAssessmentCriteriaIsPopulated_WhenValidDateWithoutPartnerAndContraryInterestIsProvided_ThenAssessmentCriteriaShouldBeReturnedWithZeroedPartnerWeightingFactor() {
-        // given Assessment Criteria is populated and matching results are returned
-        when(assessmentCriteriaRepository.findAssessmentCriteriaForDate(any(LocalDateTime.class))).thenReturn(assessmentCriteriaEntity);
-        // when Assessment Criteria valid after a certain time are requested
-        AssessmentCriteriaEntity result = assessmentCriteriaService.getAssessmentCriteria(TestModelDataBuilder.TEST_DATE_FROM.plusHours(1), false, false);
-        // then expected Assessment Criteria are returned
-        assertEquals(assessmentCriteriaEntity, result);
-        assertEquals(BigDecimal.ZERO, result.getPartnerWeightingFactor());
+    public void givenValidDateWithoutPartnerAndContraryInterest_WhenGetAssessmentCriteriaIsInvoked_ThenAssessmentCriteriaShouldBeReturnedWithZeroedPartnerWeightingFactor() {
+        when(assessmentCriteriaRepository.findAssessmentCriteriaForDate(any(LocalDateTime.class)))
+                .thenReturn(assessmentCriteriaEntity);
+
+        AssessmentCriteriaEntity result =
+                assessmentCriteriaService.getAssessmentCriteria(
+                        TestModelDataBuilder.TEST_DATE_FROM.plusHours(1), false, false
+                );
+        assertThat(assessmentCriteriaEntity).isEqualTo(result);
+        assertThat(BigDecimal.ZERO).isEqualTo(result.getPartnerWeightingFactor());
     }
 
-    @Test(expected = AssessmentCriteriaNotFoundException.class)
-    public void givenAssessmentCriteriaIsPopulated_WhenInvalidDateWithPartnerAndNoContraryInterestIsProvided_ThenAssessmentCriteriaNotFoundExceptionIsThrown() throws AssessmentCriteriaNotFoundException {
-        // given Assessment Criteria is populated and no results are returned
+    @Test
+    public void givenInvalidDateWithPartnerAndNoContraryInterest_WhenGetAssessmentCriteriaIsInvoked_ThenExceptionIsThrown() throws AssessmentCriteriaNotFoundException {
         when(assessmentCriteriaRepository.findAssessmentCriteriaForDate(any(LocalDateTime.class))).thenReturn(null);
-        // when Assessment Criteria with invalid date are requested
-        AssessmentCriteriaEntity result = assessmentCriteriaService.getAssessmentCriteria(TestModelDataBuilder.TEST_DATE_FROM.minusYears(100), true, true);
+
+        LocalDateTime criteriaDate = TestModelDataBuilder.TEST_DATE_FROM.minusYears(100);
+
+        assertThatThrownBy(
+                () -> assessmentCriteriaService.getAssessmentCriteria(criteriaDate, true, true)
+        ).isInstanceOf(AssessmentCriteriaNotFoundException.class)
+                .hasMessageContaining("No Assessment Criteria found for date " + criteriaDate);
     }
 
     @Test
     public void givenValidFrequency_whenCheckFrequencyIsInvoked_thenDoesNothing() {
-        when(assessmentCriteriaDetailFrequencyRepository.findByAssessmentCriteriaDetailAndFrequency(any(AssessmentCriteriaDetailEntity.class), any(Frequency.class))).thenReturn(
-                Optional.of(TestModelDataBuilder.getAssessmentCriteriaDetailFrequencyEntity())
-        );
+        when(assessmentCriteriaDetailFrequencyRepository.findByAssessmentCriteriaDetailAndFrequency(
+                        any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
+                )
+        ).thenReturn(Optional.of(TestModelDataBuilder.getAssessmentCriteriaDetailFrequencyEntity()));
         AssessmentCriteriaDetailEntity detail = TestModelDataBuilder.getAssessmentCriteriaDetailEntity();
         assessmentCriteriaService.checkCriteriaDetailFrequency(detail, Frequency.WEEKLY);
-        verify(assessmentCriteriaDetailFrequencyRepository).findByAssessmentCriteriaDetailAndFrequency(any(AssessmentCriteriaDetailEntity.class), any(Frequency.class));
     }
 
     @Test
     public void givenInvalidFrequency_whenCheckFrequencyIsInvoked_thenExceptionIsThrown() {
-        when(assessmentCriteriaDetailFrequencyRepository.findByAssessmentCriteriaDetailAndFrequency(any(AssessmentCriteriaDetailEntity.class), any(Frequency.class))).thenReturn(
-                Optional.empty()
-        );
+        when(assessmentCriteriaDetailFrequencyRepository.findByAssessmentCriteriaDetailAndFrequency(
+                        any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
+                )
+        ).thenReturn(Optional.empty());
         AssessmentCriteriaDetailEntity detail = TestModelDataBuilder.getAssessmentCriteriaDetailEntity();
         assertThatThrownBy(
                 () -> assessmentCriteriaService.checkCriteriaDetailFrequency(detail, Frequency.WEEKLY)
-        ).isInstanceOf(ValidationException.class).hasMessageContaining("Frequency: WEEKLY not valid for: " + detail.getDescription());
+        ).isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Frequency: WEEKLY not valid for: " + detail.getDescription());
     }
 
     @Test
@@ -133,11 +147,16 @@ public class AssessmentCriteriaServiceTest {
         ApiAssessmentDetail detail = TestModelDataBuilder.getApiAssessmentDetails().get(0);
         detail.setCriteriaDetailId(0);
 
-        assertThatThrownBy(
-                () -> assessmentCriteriaService.checkAssessmentDetail(CaseType.EITHER_WAY, section, assessmentCriteriaEntity, detail)
-        ).isInstanceOf(ValidationException.class).hasMessageContaining(
-                String.format("Section: %s criteria detail item: %d does not exist for criteria id: %s", section, detail.getCriteriaDetailId(), assessmentCriteriaEntity.getId())
-        );
+        assertThatThrownBy(() -> assessmentCriteriaService.checkAssessmentDetail(
+                        CaseType.EITHER_WAY, section, assessmentCriteriaEntity, detail
+                )
+        ).isInstanceOf(ValidationException.class)
+                .hasMessageContaining(String.format(
+                        "Section: %s criteria detail item: %d does not exist for criteria id: %s",
+                        section,
+                        detail.getCriteriaDetailId(),
+                        assessmentCriteriaEntity.getId()
+                ));
     }
 
     @Test
@@ -146,19 +165,29 @@ public class AssessmentCriteriaServiceTest {
         ApiAssessmentDetail detail = TestModelDataBuilder.getApiAssessmentDetails().get(0);
 
         assertThatThrownBy(
-                () -> assessmentCriteriaService.checkAssessmentDetail(CaseType.EITHER_WAY, section, assessmentCriteriaEntity, detail)
-        ).isInstanceOf(ValidationException.class).hasMessageContaining(
-                String.format("Section: %s criteria detail item: %d does not exist for criteria id: %s", section, detail.getCriteriaDetailId(), assessmentCriteriaEntity.getId())
-        );
+                () -> assessmentCriteriaService.checkAssessmentDetail(
+                        CaseType.EITHER_WAY, section, assessmentCriteriaEntity, detail
+                )
+        ).isInstanceOf(ValidationException.class)
+                .hasMessageContaining(String.format(
+                                "Section: %s criteria detail item: %d does not exist for criteria id: %s",
+                                section,
+                                detail.getCriteriaDetailId(),
+                                assessmentCriteriaEntity.getId()
+                        )
+                );
     }
 
     @Test
     public void givenApplicantFrequency_whenCheckAssessmentDetailIsInvoked_thenValidateApplicantFrequency() {
         String section = TestModelDataBuilder.TEST_SECTION;
         ApiAssessmentDetail detail = TestModelDataBuilder.getApiAssessmentDetails().get(0);
-        doNothing().when(assessmentCriteriaService).checkCriteriaDetailFrequency(any(AssessmentCriteriaDetailEntity.class), any(Frequency.class));
+        doNothing().when(assessmentCriteriaService)
+                .checkCriteriaDetailFrequency(any(AssessmentCriteriaDetailEntity.class), any(Frequency.class));
         assessmentCriteriaService.checkAssessmentDetail(CaseType.EITHER_WAY, section, assessmentCriteriaEntity, detail);
-        verify(assessmentCriteriaService).checkCriteriaDetailFrequency(any(AssessmentCriteriaDetailEntity.class), any(Frequency.class));
+        verify(assessmentCriteriaService).checkCriteriaDetailFrequency(
+                any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
+        );
     }
 
     @Test
@@ -168,9 +197,13 @@ public class AssessmentCriteriaServiceTest {
 
         detail.setApplicantFrequency(null);
 
-        doNothing().when(assessmentCriteriaService).checkCriteriaDetailFrequency(any(AssessmentCriteriaDetailEntity.class), any(Frequency.class));
+        doNothing().when(assessmentCriteriaService).checkCriteriaDetailFrequency(
+                any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
+        );
         assessmentCriteriaService.checkAssessmentDetail(CaseType.EITHER_WAY, section, assessmentCriteriaEntity, detail);
-        verify(assessmentCriteriaService).checkCriteriaDetailFrequency(any(AssessmentCriteriaDetailEntity.class), any(Frequency.class));
+        verify(assessmentCriteriaService).checkCriteriaDetailFrequency(
+                any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
+        );
     }
 
     @Test
@@ -182,11 +215,14 @@ public class AssessmentCriteriaServiceTest {
                 any(AssessmentCriteriaDetailEntity.class), any(CaseType.class))
         ).thenReturn(Optional.empty());
 
-        doNothing().when(assessmentCriteriaService).checkCriteriaDetailFrequency(any(AssessmentCriteriaDetailEntity.class), any(Frequency.class));
+        doNothing().when(assessmentCriteriaService).checkCriteriaDetailFrequency(
+                any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
+        );
 
         assessmentCriteriaService.checkAssessmentDetail(CaseType.EITHER_WAY, section, assessmentCriteriaEntity, detail);
         verify(caseTypeAssessmentCriteriaDetailValueRepository).findByAssessmentCriteriaDetailAndCaseType(
-                any(AssessmentCriteriaDetailEntity.class), any(CaseType.class));
+                any(AssessmentCriteriaDetailEntity.class), any(CaseType.class)
+        );
     }
 
     @Test
@@ -198,11 +234,14 @@ public class AssessmentCriteriaServiceTest {
                 any(AssessmentCriteriaDetailEntity.class), any(CaseType.class))
         ).thenReturn(Optional.of(TestModelDataBuilder.getCaseTypeAssessmentCriteriaDetailValueEntity()));
 
-        doNothing().when(assessmentCriteriaService).checkCriteriaDetailFrequency(any(AssessmentCriteriaDetailEntity.class), any(Frequency.class));
+        doNothing().when(assessmentCriteriaService).checkCriteriaDetailFrequency(
+                any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
+        );
 
         assessmentCriteriaService.checkAssessmentDetail(CaseType.EITHER_WAY, section, assessmentCriteriaEntity, detail);
         verify(caseTypeAssessmentCriteriaDetailValueRepository).findByAssessmentCriteriaDetailAndCaseType(
-                any(AssessmentCriteriaDetailEntity.class), any(CaseType.class));
+                any(AssessmentCriteriaDetailEntity.class), any(CaseType.class)
+        );
     }
 
     @Test
@@ -214,7 +253,9 @@ public class AssessmentCriteriaServiceTest {
                 any(AssessmentCriteriaDetailEntity.class), any(CaseType.class))
         ).thenReturn(Optional.of(TestModelDataBuilder.getCaseTypeAssessmentCriteriaDetailValueEntity()));
 
-        doNothing().when(assessmentCriteriaService).checkCriteriaDetailFrequency(any(AssessmentCriteriaDetailEntity.class), any(Frequency.class));
+        doNothing().when(assessmentCriteriaService).checkCriteriaDetailFrequency(
+                any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
+        );
 
         String expectedErrorMessage = "Incorrect amount entered for: " + TestModelDataBuilder.TEST_DESCRIPTION;
         ThrowableAssert.ThrowingCallable function =


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-242)

- Updated schemas to ensure the new work reason field is included in all assessment requests to the Court Data API. The previous configuration was causing issues when updating incomplete INIT assessments as the field wasn't included.
- Fixed NullPointerException when validating assessment criteria details.

