### PR TITLE
LCAM-277

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ out/
 
 # Gradle
 /.gradle/
-.gradle
 
 .DS_Store
 
@@ -49,3 +48,4 @@ docker-compose-debug.yml
 
 **/bin
 **/pgdata
+*.java-version

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/MeansAssessmentValidationProcessor.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/MeansAssessmentValidationProcessor.java
@@ -47,10 +47,9 @@ public class MeansAssessmentValidationProcessor {
         if (AssessmentRequestType.CREATE.equals(requestType) &&
                 meansAssessmentValidationService.isOutstandingAssessment(requestDTO)) {
             throw new ValidationException(MSG_INCOMPLETE_ASSESSMENT_FOUND);
-        } else {
-            if (meansAssessmentValidationService.isAssessmentModifiedByAnotherUser(requestDTO)) {
-                throw new ValidationException(ASSESSMENT_MODIFIED_BY_ANOTHER_USER);
-            }
+        } else if (AssessmentRequestType.UPDATE.equals(requestType) &&
+                meansAssessmentValidationService.isAssessmentModifiedByAnotherUser(requestDTO)) {
+            throw new ValidationException(ASSESSMENT_MODIFIED_BY_ANOTHER_USER);
         }
 
         if (AssessmentType.INIT.equals(requestDTO.getAssessmentType())) {

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/MeansAssessmentValidationProcessorTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/MeansAssessmentValidationProcessorTest.java
@@ -20,8 +20,7 @@ import java.util.Optional;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static uk.gov.justice.laa.crime.meansassessment.validation.validator.MeansAssessmentValidationProcessor.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -81,6 +80,9 @@ public class MeansAssessmentValidationProcessorTest {
         verify(meansAssessmentValidationService).isNewWorkReasonValid(createMeansAssessmentRequest);
         verify(initAssessmentValidator).validate(createMeansAssessmentRequest);
 
+        verify(fullAssessmentValidator, never()).validate(fullAssessment);
+        verify(meansAssessmentValidationService, never()).isAssessmentModifiedByAnotherUser(createMeansAssessmentRequest);
+
         assertThat(result).isEmpty();
     }
 
@@ -93,6 +95,9 @@ public class MeansAssessmentValidationProcessorTest {
         verify(meansAssessmentValidationService).isRepOrderReserved(fullAssessment);
         verify(meansAssessmentValidationService).isAssessmentModifiedByAnotherUser(fullAssessment);
         verify(fullAssessmentValidator).validate(fullAssessment);
+
+        verify(initAssessmentValidator, never()).validate(createMeansAssessmentRequest);
+        verify(meansAssessmentValidationService, never()).isOutstandingAssessment(createMeansAssessmentRequest);
 
         assertThat(result).isEmpty();
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/MeansAssessmentValidationProcessorTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/MeansAssessmentValidationProcessorTest.java
@@ -10,7 +10,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
 import uk.gov.justice.laa.crime.meansassessment.exception.ValidationException;
-import uk.gov.justice.laa.crime.meansassessment.service.MaatCourtDataService;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.AssessmentRequestType;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.AssessmentType;
 import uk.gov.justice.laa.crime.meansassessment.validation.service.MeansAssessmentValidationService;
@@ -20,7 +19,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.laa.crime.meansassessment.validation.validator.MeansAssessmentValidationProcessor.*;
 
@@ -42,9 +42,6 @@ public class MeansAssessmentValidationProcessorTest {
     MeansAssessmentRequestDTO createMeansAssessmentRequest;
 
     MeansAssessmentRequestDTO fullAssessment;
-
-    @Mock
-    private MaatCourtDataService maatCourtDataService;
 
     @Before
     public void setup() {
@@ -74,16 +71,29 @@ public class MeansAssessmentValidationProcessorTest {
     }
 
     @Test
-    public void givenInitAssessmentRequest_whenAllValidationsPass_thenValidatorDoesNotThrowException() {
+    public void givenCreateInitAssessmentRequest_whenAllValidationsPass_thenValidatorDoesNotThrowException() {
         Optional<Void> result =
-                meansAssessmentValidationProcessor.validate(createMeansAssessmentRequest, AssessmentRequestType.UPDATE);
+                meansAssessmentValidationProcessor.validate(createMeansAssessmentRequest, AssessmentRequestType.CREATE);
+
+        verify(meansAssessmentValidationService).isRoleActionValid(eq(createMeansAssessmentRequest), anyString());
+        verify(meansAssessmentValidationService).isRepOrderReserved(createMeansAssessmentRequest);
+        verify(meansAssessmentValidationService).isOutstandingAssessment(createMeansAssessmentRequest);
+        verify(meansAssessmentValidationService).isNewWorkReasonValid(createMeansAssessmentRequest);
+        verify(initAssessmentValidator).validate(createMeansAssessmentRequest);
+
         assertThat(result).isEmpty();
     }
 
     @Test
-    public void givenFullAssessmentRequest_whenAllValidationsPass_thenValidatorDoesNotThrowException() {
+    public void givenUpdateFullAssessmentRequest_whenAllValidationsPass_thenValidatorDoesNotThrowException() {
         fullAssessment.setFullAssessmentDate(LocalDateTime.now());
         Optional<Void> result = meansAssessmentValidationProcessor.validate(fullAssessment, AssessmentRequestType.UPDATE);
+
+        verify(meansAssessmentValidationService).isRoleActionValid(eq(fullAssessment), anyString());
+        verify(meansAssessmentValidationService).isRepOrderReserved(fullAssessment);
+        verify(meansAssessmentValidationService).isAssessmentModifiedByAnotherUser(fullAssessment);
+        verify(fullAssessmentValidator).validate(fullAssessment);
+
         assertThat(result).isEmpty();
     }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-277)

- Ensure that the `isAssessmentModifiedByAnotherUser` validation method is only called when updating assessments and not when creating them, as this was leading the Court Data API to return 405 errors.
- New test conditions added to ensure the correct validations are run dependant upon the request and assessment type.
