### PR TITLE
LCAM-282: Ensure timestamp is included in response

### DIFF
--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilder.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilder.java
@@ -31,7 +31,8 @@ public class MeansAssessmentResponseBuilder {
                 .withInitResult(maatApiAssessmentResponse.getInitResult())
                 .withInitResultReason(maatApiAssessmentResponse.getInitResultReason())
                 .withAdjustedIncomeValue(completedAssessment.getAdjustedIncomeValue())
-                .withAssessmentSectionSummary(completedAssessment.getMeansAssessment().getSectionSummaries());
+                .withAssessmentSectionSummary(completedAssessment.getMeansAssessment().getSectionSummaries())
+                .withUpdated(maatApiAssessmentResponse.getUpdated());
 
         AssessmentType assessmentType = completedAssessment.getMeansAssessment().getAssessmentType();
         if (AssessmentType.FULL.equals(assessmentType)) {

--- a/crime-means-assessment/src/main/resources/schemas/apiMeansAssessmentResponse.json
+++ b/crime-means-assessment/src/main/resources/schemas/apiMeansAssessmentResponse.json
@@ -128,6 +128,11 @@
     "reviewType": {
       "description": "Review Type Info",
       "existingJavaType": "uk.gov.justice.laa.crime.meansassessment.staticdata.enums.ReviewType"
+    },
+    "updated": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The date the assessment was last updated"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-282)

- Previous fix was ineffective.
- Pass the modification time of financial assessments back to the calling application.


