### PR TITLE
LCAM-321|Fix NPE during enum comparision

### DIFF
--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityService.java
@@ -70,9 +70,9 @@ public class CrownCourtEligibilityService {
     boolean hasRequiredCaseTypeAndOutcome(MeansAssessmentRequestDTO assessmentRequest) {
         CaseType caseType = assessmentRequest.getCaseType();
         MagCourtOutcome magCourtOutcome = assessmentRequest.getMagCourtOutcome();
-        return ((caseType.equals(CaseType.INDICTABLE) || caseType.equals(CaseType.CC_ALREADY))
-                && magCourtOutcome.equals(MagCourtOutcome.SENT_FOR_TRIAL)) ||
-                caseType.equals(CaseType.EITHER_WAY) && magCourtOutcome.equals(MagCourtOutcome.COMMITTED_FOR_TRIAL);
+        return ((caseType == CaseType.INDICTABLE || caseType == CaseType.CC_ALREADY)
+                && magCourtOutcome == MagCourtOutcome.SENT_FOR_TRIAL) ||
+                caseType == CaseType.EITHER_WAY && magCourtOutcome == MagCourtOutcome.COMMITTED_FOR_TRIAL;
     }
 
     Assessment getLatestAssessment(RepOrderDTO repOrder, Integer financialAssessmentId) {


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-321)

Using == comparison for comparing enums to avoid NPEs.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
