### PR TITLE
LCAM-344

### DIFF
--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/dto/maatcourtdata/ApplicantDTO.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/dto/maatcourtdata/ApplicantDTO.java
@@ -1,12 +1,12 @@
 package uk.gov.justice.laa.crime.meansassessment.dto.maatcourtdata;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -15,6 +15,12 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ApplicantDTO implements Serializable {
+
+    @JsonCreator
+    public ApplicantDTO(Integer id) {
+        this.id = id;
+    }
+
     private Integer id;
     private String firstName;
     private String lastName;


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-XXX)

- Ensure the application object can be deserialised using just an ID
- The applicant object is deserialised when retrieving a financial assessment from the Court Data API, which has been updated to only send the ID as the other information is redundant. PR for the CD API changes can be found here: https://github.com/ministryofjustice/laa-maat-court-data-api/pull/640