### PR TITLE
LCAM-614

### DIFF
--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/dto/maatcourtdata/RepOrderDTO.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/dto/maatcourtdata/RepOrderDTO.java
@@ -24,7 +24,7 @@ public class RepOrderDTO {
     private LocalDateTime dateModified;
     private String magsOutcome;
     private String magsOutcomeDate;
-    private LocalDate magsOutcomeDateSet;
+    private LocalDateTime magsOutcomeDateSet;
     private LocalDate committalDate;
     private String decisionReasonCode;
     private String crownRepOrderDecision;

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityService.java
@@ -48,18 +48,18 @@ public class CrownCourtEligibilityService {
                     NewWorkReason.FMA.equals(NewWorkReason.getFrom(initialAssessment.getNewWorkReason()));
 
             if (!isFirstMeansAssessment) {
-                boolean isInitResultPass =
-                        InitAssessmentResult.PASS.equals(InitAssessmentResult.getFrom(initialAssessment.getInitResult()));
-                boolean isDateCreatedAfterMagsOutcome =
-                        initialAssessment.getDateCreated().toLocalDate().isBefore(repOrder.getMagsOutcomeDateSet());
+                boolean isInitResultFail =
+                        InitAssessmentResult.FAIL.equals(InitAssessmentResult.getFrom(initialAssessment.getInitResult()));
+                boolean isDateCreatedBeforeMagsOutcome =
+                        initialAssessment.getDateCreated().isBefore(repOrder.getMagsOutcomeDateSet());
 
-                if (isInitResultPass || isDateCreatedAfterMagsOutcome) {
+                if (!isInitResultFail || !isDateCreatedBeforeMagsOutcome) {
                     Assessment previousAssessment = getLatestAssessment(repOrder, financialAssessmentId);
                     if (previousAssessment != null) {
                         return !hasDisqualifyingResult(previousAssessment);
                     }
-                    return true;
                 }
+                return true;
             }
         }
         Stream<Assessment> previousAssessments = getPreviousAssessments(repOrder);

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityService.java
@@ -48,12 +48,12 @@ public class CrownCourtEligibilityService {
                     NewWorkReason.FMA.equals(NewWorkReason.getFrom(initialAssessment.getNewWorkReason()));
 
             if (!isFirstMeansAssessment) {
-                boolean isInitResultFail =
-                        InitAssessmentResult.FAIL.equals(InitAssessmentResult.getFrom(initialAssessment.getInitResult()));
-                boolean isDateCreatedBeforeMagsOutcome =
-                        initialAssessment.getDateCreated().isBefore(repOrder.getMagsOutcomeDateSet());
+                boolean isInitResultPass =
+                        InitAssessmentResult.PASS.equals(InitAssessmentResult.getFrom(initialAssessment.getInitResult()));
+                boolean isDateCreatedAfterMagsOutcome =
+                        initialAssessment.getDateCreated().isAfter(repOrder.getMagsOutcomeDateSet());
 
-                if (!isInitResultFail || !isDateCreatedBeforeMagsOutcome) {
+                if (isInitResultPass || isDateCreatedAfterMagsOutcome) {
                     Assessment previousAssessment = getLatestAssessment(repOrder, financialAssessmentId);
                     if (previousAssessment != null) {
                         return !hasDisqualifyingResult(previousAssessment);

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/data/builder/TestModelDataBuilder.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/data/builder/TestModelDataBuilder.java
@@ -73,7 +73,7 @@ public class TestModelDataBuilder {
     public static final LocalDateTime TEST_INCOME_EVIDENCE_DUE_DATE =
             LocalDateTime.of(2020, 10, 5, 0, 0, 0);
 
-    public static final LocalDate TEST_MAGS_OUTCOME_DATE = LocalDate.of(2022, 6, 5);
+    public static final LocalDateTime TEST_MAGS_OUTCOME_DATE = LocalDateTime.of(2022, 6, 5, 0, 0);
     public static final LocalDateTime TEST_DATE_CREATED =
             LocalDateTime.of(2021, 10, 9, 15, 1, 25);
 
@@ -738,7 +738,7 @@ public class TestModelDataBuilder {
                 .magsOutcome(MagCourtOutcome.COMMITTED.getOutcome())
                 .magsOutcomeDate(TEST_MAGS_OUTCOME_DATE.toString())
                 .magsOutcomeDateSet(TEST_MAGS_OUTCOME_DATE)
-                .committalDate(TEST_MAGS_OUTCOME_DATE)
+                .committalDate(TEST_MAGS_OUTCOME_DATE.toLocalDate())
                 .decisionReasonCode("rder-code")
                 .crownRepOrderDecision("cc-rep-doc")
                 .crownRepOrderType("cc-rep-type")

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityServiceTest.java
@@ -95,21 +95,21 @@ public class CrownCourtEligibilityServiceTest {
     @Test
     public void givenEWCommittedReassessmentInitFailedAndDateCreatedOnMagsOutcomeDateSet_whenIsEligibilityCheckRequiredIsInvoked_thenTrueIsReturned() {
         financialAssessment.setInitResult(InitAssessmentResult.FAIL.getResult());
-        financialAssessment.setDateCreated(TestModelDataBuilder.TEST_MAGS_OUTCOME_DATE.atStartOfDay());
+        financialAssessment.setDateCreated(TestModelDataBuilder.TEST_MAGS_OUTCOME_DATE);
         assertThat(crownCourtEligibilityService.isEligibilityCheckRequired(requestDTO)).isTrue();
     }
 
     @Test
     public void givenEWCommittedReassessmentInitFailedAndDateCreatedAfterMagsOutcomeDateSet_whenIsEligibilityCheckRequiredIsInvoked_thenTrueIsReturned() {
         financialAssessment.setInitResult(InitAssessmentResult.FAIL.getResult());
-        financialAssessment.setDateCreated(TestModelDataBuilder.TEST_MAGS_OUTCOME_DATE.plusDays(1).atStartOfDay());
+        financialAssessment.setDateCreated(TestModelDataBuilder.TEST_MAGS_OUTCOME_DATE.plusDays(1));
         assertThat(crownCourtEligibilityService.isEligibilityCheckRequired(requestDTO)).isTrue();
     }
 
     @Test
     public void givenEWCommittedReassessmentInitFailedAndDateCreatedBeforeMagsOutcomeDateSet_whenIsEligibilityCheckRequiredIsInvoked_thenTrueIsReturned() {
         financialAssessment.setInitResult(InitAssessmentResult.FAIL.getResult());
-        financialAssessment.setDateCreated(TestModelDataBuilder.TEST_MAGS_OUTCOME_DATE.minusDays(1).atStartOfDay());
+        financialAssessment.setDateCreated(TestModelDataBuilder.TEST_MAGS_OUTCOME_DATE.minusDays(1));
         assertThat(crownCourtEligibilityService.isEligibilityCheckRequired(requestDTO)).isTrue();
     }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-614)

- Fix `INEL` processing bug, whereby failed `INIT` assessments performed prior to a magsOutcome being set would prevent the eligibility check from running.
- Updated `RepOrderDTO` `magsOutcomeDateSet` field to match changes to the Court Data API.

Note: This ticket is dependant upon the following PR raised for the relevant CD API changes, which can be found [here](https://github.com/ministryofjustice/laa-maat-court-data-api/pull/755).
