### PR TITLE
Fixed incorrect oauth registration config

### DIFF
--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/config/MaatApiOAuth2Client.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/config/MaatApiOAuth2Client.java
@@ -31,7 +31,7 @@ public class MaatApiOAuth2Client {
 
     private final MaatApiConfiguration config;
     private final RetryConfiguration retryConfiguration;
-    private static final String REGISTERED_ID = "maatapi";
+    private static final String REGISTERED_ID = "maat-api";
 
     public MaatApiOAuth2Client(MaatApiConfiguration config, RetryConfiguration retryConfiguration) {
         this.config = config;


### PR DESCRIPTION

Fixed incorrect oauth registration id, as the configuration in the application.yaml didn't match up with the expected id in the `OAuth2Client`.