### PR TITLE
LCAM-850

### DIFF
--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityService.java
@@ -80,8 +80,7 @@ public class CrownCourtEligibilityService implements EligibilityChecker {
     }
 
     private boolean hasDisqualifyingResult(Assessment assessment) {
-        if (assessment instanceof FinancialAssessmentDTO) {
-            FinancialAssessmentDTO means = (FinancialAssessmentDTO) assessment;
+        if (assessment instanceof FinancialAssessmentDTO means) {
             return InitAssessmentResult.PASS.equals(InitAssessmentResult.getFrom(means.getInitResult()))
                     || FullAssessmentResult.PASS.equals(FullAssessmentResult.getFrom(means.getFullResult()))
                     || FullAssessmentResult.FAIL.equals(FullAssessmentResult.getFrom(means.getFullResult()));

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/PassportAssessmentResult.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/PassportAssessmentResult.java
@@ -11,11 +11,12 @@ import java.util.stream.Stream;
 @NoArgsConstructor
 @AllArgsConstructor
 public enum PassportAssessmentResult {
-    PASS("PASS", "Gross income below the threshold"),
-    FAIL("FAIL", "Gross income above the threshold");
+    PASS("PASS"),
+    FAIL("FAIL"),
+    TEMP("TEMP"),
+    FAIL_CONTINUE("FAIL CONTINUE");
 
     private String result;
-    private String reason;
 
     public static PassportAssessmentResult getFrom(String result) {
         if (StringUtils.isBlank(result)) return null;

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/PassportAssessmentResultTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/PassportAssessmentResultTest.java
@@ -2,8 +2,6 @@ package uk.gov.justice.laa.crime.meansassessment.staticdata.enums;
 
 import org.junit.Test;
 
-import java.util.Objects;
-
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -11,10 +9,8 @@ public class PassportAssessmentResultTest {
 
     @Test
     public void givenValidResultString_whenGetFromIsInvoked_thenCorrectEnumIsReturned() {
-        PassportAssessmentResult result = PassportAssessmentResult.getFrom("PASS");
-        assertThat(PassportAssessmentResult.getFrom("PASS")).isEqualTo(PassportAssessmentResult.PASS);
-        assertThat(Objects.requireNonNull(result).getReason())
-                .isEqualTo(PassportAssessmentResult.PASS.getReason());
+        assertThat(PassportAssessmentResult.getFrom("PASS"))
+                .isEqualTo(PassportAssessmentResult.PASS);
     }
 
     @Test


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-850)

- Update `PassportAssessmentResult` enum with missing values and remove redundant reason field.
- Use pattern variable in `EligibilityService` to simplify casting.
