### PR TITLE
Lcam 710 upgrade junit5

### DIFF
--- a/crime-means-assessment/build.gradle
+++ b/crime-means-assessment/build.gradle
@@ -68,13 +68,6 @@ dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:$versions.mockwebserverVersion"
 }
 
-//excluding junit 4 as only junit.jupiter (junit 5) should be used
-configurations {
-    testImplementation {
-        exclude group: 'junit', module: 'junit'
-    }
-}
-
 test {
     dependsOn "cleanTest"
     finalizedBy jacocoTestReport

--- a/crime-means-assessment/build.gradle
+++ b/crime-means-assessment/build.gradle
@@ -68,6 +68,13 @@ dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:$versions.mockwebserverVersion"
 }
 
+//excluding junit 4 as only junit.jupiter (junit 5) should be used
+configurations {
+    testImplementation {
+        exclude group: 'junit', module: 'junit'
+    }
+}
+
 test {
     dependsOn "cleanTest"
     finalizedBy jacocoTestReport

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MaatCourtDataAssessmentBuilderTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MaatCourtDataAssessmentBuilderTest.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
- class MaatCourtDataAssessmentBuilderTest {
+class MaatCourtDataAssessmentBuilderTest {
 
     private final MaatCourtDataAssessmentBuilder requestDTOBuilder =
             new MaatCourtDataAssessmentBuilder();
@@ -120,7 +120,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenCreateRequestType_whenBuildAssessmentRequestIsInvoked_thenCreateFieldsArePopulated() {
+    void givenCreateRequestType_whenBuildAssessmentRequestIsInvoked_thenCreateFieldsArePopulated() {
         MaatApiAssessmentRequest resultDto =
                 requestDTOBuilder.build(assessmentDTO, AssessmentRequestType.CREATE);
 
@@ -134,7 +134,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenUpdateRequestType_whenBuildAssessmentRequestIsInvoked_thenUpdateFieldsArePopulated() {
+    void givenUpdateRequestType_whenBuildAssessmentRequestIsInvoked_thenUpdateFieldsArePopulated() {
         MaatApiAssessmentRequest resultDto =
                 requestDTOBuilder.build(assessmentDTO, AssessmentRequestType.UPDATE);
 
@@ -148,7 +148,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenUpdateRequestType_whenBuildFullAssessmentRequestIsInvoked_thenChildWeightingsAreNotArePopulated() {
+    void givenUpdateRequestType_whenBuildFullAssessmentRequestIsInvoked_thenChildWeightingsAreNotArePopulated() {
         assessmentDTO.getMeansAssessment().setAssessmentType(AssessmentType.FULL);
         MaatApiAssessmentRequest resultDto =
                 requestDTOBuilder.build(assessmentDTO, AssessmentRequestType.UPDATE);

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MaatCourtDataAssessmentBuilderTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MaatCourtDataAssessmentBuilderTest.java
@@ -1,7 +1,7 @@
 package uk.gov.justice.laa.crime.meansassessment.builder;
 
 import org.assertj.core.api.SoftAssertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentDTO;
 import uk.gov.justice.laa.crime.meansassessment.model.common.maatapi.MaatApiAssessmentRequest;
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class MaatCourtDataAssessmentBuilderTest {
+ class MaatCourtDataAssessmentBuilderTest {
 
     private final MaatCourtDataAssessmentBuilder requestDTOBuilder =
             new MaatCourtDataAssessmentBuilder();
@@ -120,7 +120,7 @@ public class MaatCourtDataAssessmentBuilderTest {
     }
 
     @Test
-    public void givenCreateRequestType_whenBuildAssessmentRequestIsInvoked_thenCreateFieldsArePopulated() {
+     void givenCreateRequestType_whenBuildAssessmentRequestIsInvoked_thenCreateFieldsArePopulated() {
         MaatApiAssessmentRequest resultDto =
                 requestDTOBuilder.build(assessmentDTO, AssessmentRequestType.CREATE);
 
@@ -134,7 +134,7 @@ public class MaatCourtDataAssessmentBuilderTest {
     }
 
     @Test
-    public void givenUpdateRequestType_whenBuildAssessmentRequestIsInvoked_thenUpdateFieldsArePopulated() {
+     void givenUpdateRequestType_whenBuildAssessmentRequestIsInvoked_thenUpdateFieldsArePopulated() {
         MaatApiAssessmentRequest resultDto =
                 requestDTOBuilder.build(assessmentDTO, AssessmentRequestType.UPDATE);
 
@@ -148,7 +148,7 @@ public class MaatCourtDataAssessmentBuilderTest {
     }
 
     @Test
-    public void givenUpdateRequestType_whenBuildFullAssessmentRequestIsInvoked_thenChildWeightingsAreNotArePopulated() {
+     void givenUpdateRequestType_whenBuildFullAssessmentRequestIsInvoked_thenChildWeightingsAreNotArePopulated() {
         assessmentDTO.getMeansAssessment().setAssessmentType(AssessmentType.FULL);
         MaatApiAssessmentRequest resultDto =
                 requestDTOBuilder.build(assessmentDTO, AssessmentRequestType.UPDATE);

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentRequestDTOBuilderTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentRequestDTOBuilderTest.java
@@ -10,13 +10,13 @@ import uk.gov.justice.laa.crime.meansassessment.model.common.ApiUpdateMeansAsses
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
- class MeansAssessmentRequestDTOBuilderTest {
+class MeansAssessmentRequestDTOBuilderTest {
 
     private final MeansAssessmentRequestDTOBuilder requestDTOBuilder =
             new MeansAssessmentRequestDTOBuilder();
 
     @Test
-     void givenMeansAssessmentRequest_whenBuildRequestDTOisInvoked_thenCommonFieldsArePopulated() {
+    void givenMeansAssessmentRequest_whenBuildRequestDTOisInvoked_thenCommonFieldsArePopulated() {
         ApiMeansAssessmentRequest meansAssessment =
                 TestModelDataBuilder.getApiMeansAssessmentRequest(true);
 
@@ -46,7 +46,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenInitMeansAssessmentRequest_whenBuildRequestDTOIsInvoked_thenInitFieldsArePopulated() {
+    void givenInitMeansAssessmentRequest_whenBuildRequestDTOIsInvoked_thenInitFieldsArePopulated() {
         ApiCreateMeansAssessmentRequest createMeansAssessment =
                 TestModelDataBuilder.getApiCreateMeansAssessmentRequest(true);
 
@@ -60,7 +60,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenFullMeansAssessmentRequest_whenBuildRequestDTOIsInvoked_thenFullFieldsArePopulated() {
+    void givenFullMeansAssessmentRequest_whenBuildRequestDTOIsInvoked_thenFullFieldsArePopulated() {
         ApiUpdateMeansAssessmentRequest updateMeansAssessment =
                 TestModelDataBuilder.getApiUpdateMeansAssessmentRequest(true);
 

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentRequestDTOBuilderTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentRequestDTOBuilderTest.java
@@ -1,7 +1,7 @@
 package uk.gov.justice.laa.crime.meansassessment.builder;
 
 import org.assertj.core.api.SoftAssertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
 import uk.gov.justice.laa.crime.meansassessment.model.common.ApiCreateMeansAssessmentRequest;
@@ -10,13 +10,13 @@ import uk.gov.justice.laa.crime.meansassessment.model.common.ApiUpdateMeansAsses
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class MeansAssessmentRequestDTOBuilderTest {
+ class MeansAssessmentRequestDTOBuilderTest {
 
     private final MeansAssessmentRequestDTOBuilder requestDTOBuilder =
             new MeansAssessmentRequestDTOBuilder();
 
     @Test
-    public void givenMeansAssessmentRequest_whenBuildRequestDTOisInvoked_thenCommonFieldsArePopulated() {
+     void givenMeansAssessmentRequest_whenBuildRequestDTOisInvoked_thenCommonFieldsArePopulated() {
         ApiMeansAssessmentRequest meansAssessment =
                 TestModelDataBuilder.getApiMeansAssessmentRequest(true);
 
@@ -46,7 +46,7 @@ public class MeansAssessmentRequestDTOBuilderTest {
     }
 
     @Test
-    public void givenInitMeansAssessmentRequest_whenBuildRequestDTOIsInvoked_thenInitFieldsArePopulated() {
+     void givenInitMeansAssessmentRequest_whenBuildRequestDTOIsInvoked_thenInitFieldsArePopulated() {
         ApiCreateMeansAssessmentRequest createMeansAssessment =
                 TestModelDataBuilder.getApiCreateMeansAssessmentRequest(true);
 
@@ -60,7 +60,7 @@ public class MeansAssessmentRequestDTOBuilderTest {
     }
 
     @Test
-    public void givenFullMeansAssessmentRequest_whenBuildRequestDTOIsInvoked_thenFullFieldsArePopulated() {
+     void givenFullMeansAssessmentRequest_whenBuildRequestDTOIsInvoked_thenFullFieldsArePopulated() {
         ApiUpdateMeansAssessmentRequest updateMeansAssessment =
                 TestModelDataBuilder.getApiUpdateMeansAssessmentRequest(true);
 

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilderTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilderTest.java
@@ -1,8 +1,8 @@
 package uk.gov.justice.laa.crime.meansassessment.builder;
 
 import org.assertj.core.api.SoftAssertions;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentDTO;
 import uk.gov.justice.laa.crime.meansassessment.model.common.ApiMeansAssessmentResponse;
@@ -12,7 +12,7 @@ import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.AssessmentType;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class MeansAssessmentResponseBuilderTest {
+ class MeansAssessmentResponseBuilderTest {
 
     private final MeansAssessmentResponseBuilder responseBuilder =
             new MeansAssessmentResponseBuilder();
@@ -21,8 +21,8 @@ public class MeansAssessmentResponseBuilderTest {
     private MeansAssessmentDTO completedAssessment;
     private MaatApiAssessmentResponse maatApiAssessmentResponse;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+     void setup() {
         completedAssessment = TestModelDataBuilder.getMeansAssessmentDTO();
         maatApiAssessmentResponse = TestModelDataBuilder.getMaatApiInitAssessmentResponse();
     }
@@ -53,7 +53,7 @@ public class MeansAssessmentResponseBuilderTest {
     }
 
     @Test
-    public void givenInitAssessmentType_whenBuildIsInvoked_thenCommonFieldsArePopulated() {
+     void givenInitAssessmentType_whenBuildIsInvoked_thenCommonFieldsArePopulated() {
         ApiMeansAssessmentResponse response =
                 responseBuilder.build(maatApiAssessmentResponse, assessmentCriteria, completedAssessment);
         checkCommonFieldsPopulated(response);
@@ -62,7 +62,7 @@ public class MeansAssessmentResponseBuilderTest {
     }
 
     @Test
-    public void givenFullAssessmentType_whenBuildIsInvoked_thenFullFieldsArePopulated() {
+     void givenFullAssessmentType_whenBuildIsInvoked_thenFullFieldsArePopulated() {
         completedAssessment.getMeansAssessment().setAssessmentType(AssessmentType.FULL);
         ApiMeansAssessmentResponse response =
                 responseBuilder.build(maatApiAssessmentResponse, assessmentCriteria, completedAssessment);

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilderTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilderTest.java
@@ -12,7 +12,7 @@ import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.AssessmentType;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
- class MeansAssessmentResponseBuilderTest {
+class MeansAssessmentResponseBuilderTest {
 
     private final MeansAssessmentResponseBuilder responseBuilder =
             new MeansAssessmentResponseBuilder();
@@ -22,7 +22,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     private MaatApiAssessmentResponse maatApiAssessmentResponse;
 
     @BeforeEach
-     void setup() {
+    void setup() {
         completedAssessment = TestModelDataBuilder.getMeansAssessmentDTO();
         maatApiAssessmentResponse = TestModelDataBuilder.getMaatApiInitAssessmentResponse();
     }
@@ -53,7 +53,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenInitAssessmentType_whenBuildIsInvoked_thenCommonFieldsArePopulated() {
+    void givenInitAssessmentType_whenBuildIsInvoked_thenCommonFieldsArePopulated() {
         ApiMeansAssessmentResponse response =
                 responseBuilder.build(maatApiAssessmentResponse, assessmentCriteria, completedAssessment);
         checkCommonFieldsPopulated(response);
@@ -62,7 +62,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenFullAssessmentType_whenBuildIsInvoked_thenFullFieldsArePopulated() {
+    void givenFullAssessmentType_whenBuildIsInvoked_thenFullFieldsArePopulated() {
         completedAssessment.getMeansAssessment().setAssessmentType(AssessmentType.FULL);
         ApiMeansAssessmentResponse response =
                 responseBuilder.build(maatApiAssessmentResponse, assessmentCriteria, completedAssessment);

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentSectionSummaryBuilderTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentSectionSummaryBuilderTest.java
@@ -25,9 +25,9 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {CrimeMeansAssessmentApplication.class})
- class MeansAssessmentSectionSummaryBuilderTest {
+class MeansAssessmentSectionSummaryBuilderTest {
 
-     static final BigDecimal EXPECTED_AMOUNT = new BigDecimal("280.00");
+    static final BigDecimal EXPECTED_AMOUNT = new BigDecimal("280.00");
     private final MeansAssessmentSectionSummaryBuilder meansAssessmentSectionSummaryBuilder
             = new MeansAssessmentSectionSummaryBuilder();
 
@@ -35,7 +35,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     private ObjectMapper objectMapper;
 
     @Test
-     void givenInvalidASectionAssessment_whenBuildInvoked_shouldReturnEmpty() {
+    void givenInvalidASectionAssessment_whenBuildInvoked_shouldReturnEmpty() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TEST_SECTION, TEST_SEQ));
@@ -44,7 +44,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenInitASectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
+    void givenInitASectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TEST_ASSESSMENT_SECTION_INITA, TEST_SEQ));
@@ -61,7 +61,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenInitBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
+    void givenInitBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TEST_ASSESSMENT_SECTION_INITB, TEST_SEQ));
@@ -78,7 +78,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenBothInitAAndIntBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
+    void givenBothInitAAndIntBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TEST_ASSESSMENT_SECTION_INITA, TEST_SEQ));
@@ -103,7 +103,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenFullASectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
+    void givenFullASectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TEST_ASSESSMENT_SECTION_FULLA, TEST_SEQ));
@@ -120,7 +120,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenBothFullAAndFullBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
+    void givenBothFullAAndFullBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TEST_ASSESSMENT_SECTION_FULLA, TEST_SEQ));
@@ -145,7 +145,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenFullBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
+    void givenFullBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TEST_ASSESSMENT_SECTION_FULLB, TEST_SEQ));
@@ -162,7 +162,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenValidAssessment_whenGetAssessmentDetailInvoked_shouldReturnAssessmentDetails() {
+    void givenValidAssessment_whenGetAssessmentDetailInvoked_shouldReturnAssessmentDetails() {
 
         ApiAssessmentDetail assessmentDetail = meansAssessmentSectionSummaryBuilder.
                 getAssessmentDetail(TestModelDataBuilder.getAssessmentDTO(TEST_ASSESSMENT_SECTION_INITA, TEST_SEQ));
@@ -176,7 +176,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenValidAssessmentCriteriaDetail_whenBuildAssessmentDTOInvoked_shouldReturnAssessment() {
+    void givenValidAssessmentCriteriaDetail_whenBuildAssessmentDTOInvoked_shouldReturnAssessment() {
 
         AssessmentDTO assessmentDTO = meansAssessmentSectionSummaryBuilder.
                 buildAssessmentDTO(TestModelDataBuilder.getAssessmentCriteriaDetailEntity(TestModelDataBuilder.TEST_SECTION),
@@ -196,7 +196,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenValidAssessmentAmt_whenGetAssessmentSectionSummaryTotalInvoked_shouldReturnAssessmentAmt() {
+    void givenValidAssessmentAmt_whenGetAssessmentSectionSummaryTotalInvoked_shouldReturnAssessmentAmt() {
 
         BigDecimal assessmentAmt = meansAssessmentSectionSummaryBuilder
                 .getAssessmentSectionSummaryTotal(TestModelDataBuilder.TEST_APPLICANT_VALUE, TEST_FREQUENCY);
@@ -204,7 +204,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenInvalidFrequency_whenGetAssessmentSectionSummaryTotalInvoked_shouldReturnZero() {
+    void givenInvalidFrequency_whenGetAssessmentSectionSummaryTotalInvoked_shouldReturnZero() {
 
         BigDecimal assessmentAmt = meansAssessmentSectionSummaryBuilder
                 .getAssessmentSectionSummaryTotal(TestModelDataBuilder.TEST_APPLICANT_VALUE, null);
@@ -212,7 +212,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenAValidFinancialAssessment_whenBuildInitialAssessmentInvoked_shouldBuildInitialAssessment() throws Exception {
+    void givenAValidFinancialAssessment_whenBuildInitialAssessmentInvoked_shouldBuildInitialAssessment() throws Exception {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setInitialAssessment(new ApiInitialMeansAssessment());
@@ -233,7 +233,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenEmptyCurrentStatus_whenBuildInitialAssessmentInvoked_shouldNotReturnAssessmentStatus() {
+    void givenEmptyCurrentStatus_whenBuildInitialAssessmentInvoked_shouldNotReturnAssessmentStatus() {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setInitialAssessment(new ApiInitialMeansAssessment());
@@ -246,7 +246,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenEmptyWorkReason_whenBuildInitialAssessmentInvoked_shouldNotReturnNewWorkReason() {
+    void givenEmptyWorkReason_whenBuildInitialAssessmentInvoked_shouldNotReturnNewWorkReason() {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setInitialAssessment(new ApiInitialMeansAssessment());
@@ -259,7 +259,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenEmptyReview_whenBuildInitialAssessmentInvoked_shouldNotReturnReviewType() {
+    void givenEmptyReview_whenBuildInitialAssessmentInvoked_shouldNotReturnReviewType() {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setInitialAssessment(new ApiInitialMeansAssessment());
@@ -272,7 +272,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenEmptyAssessmentCriteriaEntity_whenBuildInitialAssessmentInvoked_shouldNotReturnThreshold() {
+    void givenEmptyAssessmentCriteriaEntity_whenBuildInitialAssessmentInvoked_shouldNotReturnThreshold() {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setInitialAssessment(new ApiInitialMeansAssessment());
@@ -286,7 +286,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenAValidFinancialAssessment_whenBuildFullAssessmentInvoked_shouldBuildFullAssessment() throws Exception {
+    void givenAValidFinancialAssessment_whenBuildFullAssessmentInvoked_shouldBuildFullAssessment() throws Exception {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setFullAssessment(new ApiFullMeansAssessment());
@@ -307,7 +307,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenEmptyCurrentStatus_whenBuildFullAssessmentInvoked_shouldNotReturnCurrentStatus() throws Exception {
+    void givenEmptyCurrentStatus_whenBuildFullAssessmentInvoked_shouldNotReturnCurrentStatus() throws Exception {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setFullAssessment(new ApiFullMeansAssessment());
@@ -328,7 +328,7 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
     }
 
     @Test
-     void givenEmptyAssessmentCriteriaEntity_whenBuildFullAssessmentInvoked_shouldNotReturnThreshold() throws Exception {
+    void givenEmptyAssessmentCriteriaEntity_whenBuildFullAssessmentInvoked_shouldNotReturnThreshold() throws Exception {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setFullAssessment(new ApiFullMeansAssessment());

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentSectionSummaryBuilderTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentSectionSummaryBuilderTest.java
@@ -2,11 +2,11 @@ package uk.gov.justice.laa.crime.meansassessment.builder;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.justice.laa.crime.meansassessment.CrimeMeansAssessmentApplication;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.AssessmentDTO;
@@ -23,11 +23,11 @@ import java.util.Optional;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder.*;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {CrimeMeansAssessmentApplication.class})
-public class MeansAssessmentSectionSummaryBuilderTest {
+ class MeansAssessmentSectionSummaryBuilderTest {
 
-    public static final BigDecimal EXPECTED_AMOUNT = new BigDecimal("280.00");
+     static final BigDecimal EXPECTED_AMOUNT = new BigDecimal("280.00");
     private final MeansAssessmentSectionSummaryBuilder meansAssessmentSectionSummaryBuilder
             = new MeansAssessmentSectionSummaryBuilder();
 
@@ -35,7 +35,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     private ObjectMapper objectMapper;
 
     @Test
-    public void givenInvalidASectionAssessment_whenBuildInvoked_shouldReturnEmpty() {
+     void givenInvalidASectionAssessment_whenBuildInvoked_shouldReturnEmpty() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TEST_SECTION, TEST_SEQ));
@@ -44,7 +44,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenInitASectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
+     void givenInitASectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TEST_ASSESSMENT_SECTION_INITA, TEST_SEQ));
@@ -61,7 +61,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenInitBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
+     void givenInitBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TEST_ASSESSMENT_SECTION_INITB, TEST_SEQ));
@@ -78,7 +78,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenBothInitAAndIntBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
+     void givenBothInitAAndIntBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TEST_ASSESSMENT_SECTION_INITA, TEST_SEQ));
@@ -103,7 +103,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenFullASectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
+     void givenFullASectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TEST_ASSESSMENT_SECTION_FULLA, TEST_SEQ));
@@ -120,7 +120,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenBothFullAAndFullBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
+     void givenBothFullAAndFullBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TEST_ASSESSMENT_SECTION_FULLA, TEST_SEQ));
@@ -145,7 +145,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenFullBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
+     void givenFullBSectionAssessment_whenBuildInvoked_shouldReturnInitialAssessmentSummary() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TEST_ASSESSMENT_SECTION_FULLB, TEST_SEQ));
@@ -162,7 +162,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenValidAssessment_whenGetAssessmentDetailInvoked_shouldReturnAssessmentDetails() {
+     void givenValidAssessment_whenGetAssessmentDetailInvoked_shouldReturnAssessmentDetails() {
 
         ApiAssessmentDetail assessmentDetail = meansAssessmentSectionSummaryBuilder.
                 getAssessmentDetail(TestModelDataBuilder.getAssessmentDTO(TEST_ASSESSMENT_SECTION_INITA, TEST_SEQ));
@@ -176,7 +176,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenValidAssessmentCriteriaDetail_whenBuildAssessmentDTOInvoked_shouldReturnAssessment() {
+     void givenValidAssessmentCriteriaDetail_whenBuildAssessmentDTOInvoked_shouldReturnAssessment() {
 
         AssessmentDTO assessmentDTO = meansAssessmentSectionSummaryBuilder.
                 buildAssessmentDTO(TestModelDataBuilder.getAssessmentCriteriaDetailEntity(TestModelDataBuilder.TEST_SECTION),
@@ -196,7 +196,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenValidAssessmentAmt_whenGetAssessmentSectionSummaryTotalInvoked_shouldReturnAssessmentAmt() {
+     void givenValidAssessmentAmt_whenGetAssessmentSectionSummaryTotalInvoked_shouldReturnAssessmentAmt() {
 
         BigDecimal assessmentAmt = meansAssessmentSectionSummaryBuilder
                 .getAssessmentSectionSummaryTotal(TestModelDataBuilder.TEST_APPLICANT_VALUE, TEST_FREQUENCY);
@@ -204,7 +204,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenInvalidFrequency_whenGetAssessmentSectionSummaryTotalInvoked_shouldReturnZero() {
+     void givenInvalidFrequency_whenGetAssessmentSectionSummaryTotalInvoked_shouldReturnZero() {
 
         BigDecimal assessmentAmt = meansAssessmentSectionSummaryBuilder
                 .getAssessmentSectionSummaryTotal(TestModelDataBuilder.TEST_APPLICANT_VALUE, null);
@@ -212,7 +212,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenAValidFinancialAssessment_whenBuildInitialAssessmentInvoked_shouldBuildInitialAssessment() throws Exception {
+     void givenAValidFinancialAssessment_whenBuildInitialAssessmentInvoked_shouldBuildInitialAssessment() throws Exception {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setInitialAssessment(new ApiInitialMeansAssessment());
@@ -233,7 +233,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenEmptyCurrentStatus_whenBuildInitialAssessmentInvoked_shouldNotReturnAssessmentStatus() {
+     void givenEmptyCurrentStatus_whenBuildInitialAssessmentInvoked_shouldNotReturnAssessmentStatus() {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setInitialAssessment(new ApiInitialMeansAssessment());
@@ -246,7 +246,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenEmptyWorkReason_whenBuildInitialAssessmentInvoked_shouldNotReturnNewWorkReason() {
+     void givenEmptyWorkReason_whenBuildInitialAssessmentInvoked_shouldNotReturnNewWorkReason() {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setInitialAssessment(new ApiInitialMeansAssessment());
@@ -259,7 +259,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenEmptyReview_whenBuildInitialAssessmentInvoked_shouldNotReturnReviewType() {
+     void givenEmptyReview_whenBuildInitialAssessmentInvoked_shouldNotReturnReviewType() {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setInitialAssessment(new ApiInitialMeansAssessment());
@@ -272,7 +272,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenEmptyAssessmentCriteriaEntity_whenBuildInitialAssessmentInvoked_shouldNotReturnThreshold() {
+     void givenEmptyAssessmentCriteriaEntity_whenBuildInitialAssessmentInvoked_shouldNotReturnThreshold() {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setInitialAssessment(new ApiInitialMeansAssessment());
@@ -286,7 +286,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenAValidFinancialAssessment_whenBuildFullAssessmentInvoked_shouldBuildFullAssessment() throws Exception {
+     void givenAValidFinancialAssessment_whenBuildFullAssessmentInvoked_shouldBuildFullAssessment() throws Exception {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setFullAssessment(new ApiFullMeansAssessment());
@@ -307,7 +307,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenEmptyCurrentStatus_whenBuildFullAssessmentInvoked_shouldNotReturnCurrentStatus() throws Exception {
+     void givenEmptyCurrentStatus_whenBuildFullAssessmentInvoked_shouldNotReturnCurrentStatus() throws Exception {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setFullAssessment(new ApiFullMeansAssessment());
@@ -328,7 +328,7 @@ public class MeansAssessmentSectionSummaryBuilderTest {
     }
 
     @Test
-    public void givenEmptyAssessmentCriteriaEntity_whenBuildFullAssessmentInvoked_shouldNotReturnThreshold() throws Exception {
+     void givenEmptyAssessmentCriteriaEntity_whenBuildFullAssessmentInvoked_shouldNotReturnThreshold() throws Exception {
 
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         response.setFullAssessment(new ApiFullMeansAssessment());

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/config/MaatApiConfigurationTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/config/MaatApiConfigurationTest.java
@@ -23,14 +23,6 @@ class MaatApiConfigurationTest {
     @Qualifier("test_configuration")
     private MaatApiConfiguration configuration;
 
-    @Configuration
-    static class MaatApiConfigurationFactory {
-        @Bean(name = "test_configuration")
-        MaatApiConfiguration getDefaultConfiguration() {
-            return new MaatApiConfiguration();
-        }
-    }
-
     @Test
     void givenUserDefinedPOJO_whenBindingYMLConfigFile_thenAllFieldsAreSet() {
         assertThat(buildUrl("search-url")).isEqualTo(configuration.getFinancialAssessmentEndpoints().getSearchUrl());
@@ -57,5 +49,13 @@ class MaatApiConfigurationTest {
 
     private String buildUrl(String url) {
         return String.format("http://localhost:9999/api/internal/v1/assessment/%s", url);
+    }
+
+    @Configuration
+    static class MaatApiConfigurationFactory {
+        @Bean(name = "test_configuration")
+        MaatApiConfiguration getDefaultConfiguration() {
+            return new MaatApiConfiguration();
+        }
     }
 }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/config/MaatApiConfigurationTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/config/MaatApiConfigurationTest.java
@@ -1,7 +1,7 @@
 package uk.gov.justice.laa.crime.meansassessment.config;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -9,30 +9,30 @@ import org.springframework.boot.test.context.ConfigDataApplicationContextInitial
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.AssessmentRequestType;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @EnableConfigurationProperties(value = MaatApiConfiguration.class)
 @ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
-public class MaatApiConfigurationTest {
+class MaatApiConfigurationTest {
 
     @Autowired
     @Qualifier("test_configuration")
     private MaatApiConfiguration configuration;
 
     @Configuration
-    public static class MaatApiConfigurationFactory {
+    static class MaatApiConfigurationFactory {
         @Bean(name = "test_configuration")
-        public MaatApiConfiguration getDefaultConfiguration() {
+        MaatApiConfiguration getDefaultConfiguration() {
             return new MaatApiConfiguration();
         }
     }
 
     @Test
-    public void givenUserDefinedPOJO_whenBindingYMLConfigFile_thenAllFieldsAreSet() {
+    void givenUserDefinedPOJO_whenBindingYMLConfigFile_thenAllFieldsAreSet() {
         assertThat(buildUrl("search-url")).isEqualTo(configuration.getFinancialAssessmentEndpoints().getSearchUrl());
         assertThat(buildUrl("create-url")).isEqualTo(configuration.getFinancialAssessmentEndpoints().getCreateUrl());
         assertThat(buildUrl("update-url")).isEqualTo(configuration.getFinancialAssessmentEndpoints().getUpdateUrl());
@@ -46,12 +46,12 @@ public class MaatApiConfigurationTest {
     }
 
     @Test
-    public void givenDefinedFinancialAssessmentEndpoints_whenGetByRequestTypeIsInvoked_thenCorrectEndpointIsReturned() {
+    void givenDefinedFinancialAssessmentEndpoints_whenGetByRequestTypeIsInvoked_thenCorrectEndpointIsReturned() {
         assertThat(buildUrl("create-url")).isEqualTo(configuration.getFinancialAssessmentEndpoints().getByRequestType(AssessmentRequestType.CREATE));
     }
 
     @Test
-    public void givenDefinedPostProcessingUrl_whenGetPostProcessingUrl_thenCorrectEndpointIsReturned() {
+    void givenDefinedPostProcessingUrl_whenGetPostProcessingUrl_thenCorrectEndpointIsReturned() {
         assertThat(buildUrl("post-processing/{repId}")).isEqualTo(configuration.getPostProcessingUrl());
     }
 

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/MeansAssessmentControllerTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/MeansAssessmentControllerTest.java
@@ -1,8 +1,8 @@
 package uk.gov.justice.laa.crime.meansassessment.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -10,7 +10,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.justice.laa.crime.meansassessment.builder.MeansAssessmentRequestDTOBuilder;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
@@ -31,10 +31,10 @@ import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDat
 import static uk.gov.justice.laa.crime.meansassessment.util.RequestBuilderUtils.buildRequestGivenContent;
 
 @DirtiesContext
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(MeansAssessmentController.class)
-public class MeansAssessmentControllerTest {
+class MeansAssessmentControllerTest {
 
     private static final boolean IS_VALID = true;
     private static final String ENDPOINT_URL = "/api/internal/v1/assessment/means";
@@ -55,7 +55,7 @@ public class MeansAssessmentControllerTest {
     private MeansAssessmentValidationProcessor assessmentValidator;
 
     @Test
-    public void createAssessment_success() throws Exception {
+    void createAssessment_success() throws Exception {
         var initialMeansAssessmentRequest =
                 TestModelDataBuilder.getApiCreateMeansAssessmentRequest(IS_VALID);
         var initialMeansAssessmentRequestJson = objectMapper.writeValueAsString(initialMeansAssessmentRequest);
@@ -78,7 +78,7 @@ public class MeansAssessmentControllerTest {
     }
 
     @Test
-    public void updateAssessment_success() throws Exception {
+    void updateAssessment_success() throws Exception {
         var updateAssessmentRequest =
                 TestModelDataBuilder.getApiUpdateMeansAssessmentRequest(IS_VALID);
         var updateAssessmentRequestJson = objectMapper.writeValueAsString(updateAssessmentRequest);
@@ -101,7 +101,7 @@ public class MeansAssessmentControllerTest {
     }
 
     @Test
-    public void createAssessment_RequestObjectFailsValidation() throws Exception {
+    void createAssessment_RequestObjectFailsValidation() throws Exception {
         var createAssessmentRequest =
                 TestModelDataBuilder.getApiCreateMeansAssessmentRequest(!IS_VALID);
         var createAssessmentRequestJson = objectMapper.writeValueAsString(createAssessmentRequest);
@@ -111,7 +111,7 @@ public class MeansAssessmentControllerTest {
     }
 
     @Test
-    public void updateAssessment_RequestObjectFailsValidation() throws Exception {
+    void updateAssessment_RequestObjectFailsValidation() throws Exception {
         var updateAssessmentRequest =
                 TestModelDataBuilder.getApiUpdateMeansAssessmentRequest(!IS_VALID);
         var updateAssessmentRequestJson = objectMapper.writeValueAsString(updateAssessmentRequest);
@@ -121,37 +121,37 @@ public class MeansAssessmentControllerTest {
     }
 
     @Test
-    public void createAssessment_ServerError_RequestBodyIsMissing() throws Exception {
+    void createAssessment_ServerError_RequestBodyIsMissing() throws Exception {
         mvc.perform(buildRequestGivenContent(HttpMethod.POST, "", ENDPOINT_URL))
                 .andExpect(status().is4xxClientError());
     }
 
     @Test
-    public void createAssessment_BadRequest_RequestEmptyBody() throws Exception {
+    void createAssessment_BadRequest_RequestEmptyBody() throws Exception {
         mvc.perform(buildRequestGivenContent(HttpMethod.POST, "{}", ENDPOINT_URL))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
-    public void updateAssessment_ServerError_RequestBodyIsMissing() throws Exception {
+    void updateAssessment_ServerError_RequestBodyIsMissing() throws Exception {
         mvc.perform(buildRequestGivenContent(HttpMethod.PUT, "", ENDPOINT_URL))
                 .andExpect(status().is4xxClientError());
     }
 
     @Test
-    public void updateAssessment_BadRequest_RequestEmptyBody() throws Exception {
+    void updateAssessment_BadRequest_RequestEmptyBody() throws Exception {
         mvc.perform(buildRequestGivenContent(HttpMethod.PUT, "{}", ENDPOINT_URL))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
-    public void givenInvalidPram_whenGetOldAssessmentInvoked_shouldFailBadRequest() throws Exception {
+    void givenInvalidPram_whenGetOldAssessmentInvoked_shouldFailBadRequest() throws Exception {
         mvc.perform(buildRequestGivenContent(HttpMethod.GET, "", ENDPOINT_URL, true))
                 .andExpect(status().is4xxClientError());
     }
 
     @Test
-    public void givenValidPram_whenGetOldAssessmentInvoked_shouldSuccess() throws Exception {
+    void givenValidPram_whenGetOldAssessmentInvoked_shouldSuccess() throws Exception {
         when(meansAssessmentService.getOldAssessment(any(), any())).thenReturn(new ApiGetMeansAssessmentResponse());
         mvc.perform(buildRequestGivenContent(
                 HttpMethod.GET,

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/MeansAssessmentIntegrationTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/MeansAssessmentIntegrationTest.java
@@ -52,7 +52,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         classes = {
                 CrimeMeansAssessmentApplication.class, MeansAssessmentResponseBuilder.class
         }, webEnvironment = DEFINED_PORT)
- class MeansAssessmentIntegrationTest {
+class MeansAssessmentIntegrationTest {
 
     private static final boolean IS_VALID = true;
     private static final String ENDPOINT_URL = "/api/internal/v1/assessment/means";
@@ -68,19 +68,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     private FilterChainProxy springSecurityFilterChain;
 
     @BeforeAll
-     static void initialiseMockWebServer() throws IOException {
+    static void initialiseMockWebServer() throws IOException {
         mockMaatCourtDataApi = new MockWebServer();
         mockMaatCourtDataApi.start(9999);
         mockMaatCourtDataApi.setDispatcher(MockWebServerStubs.getDispatcher());
     }
 
     @AfterAll
-     static void shutdownMockWebServer() throws IOException {
+    static void shutdownMockWebServer() throws IOException {
         mockMaatCourtDataApi.shutdown();
     }
 
     @BeforeEach
-     void setup() {
+    void setup() {
         this.mvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext)
                 .addFilter(springSecurityFilterChain).build();
     }
@@ -109,19 +109,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     }
 
     @Test
-     void givenAInvalidContent_whenCreateAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
+    void givenAInvalidContent_whenCreateAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
         mvc.perform(buildRequest(HttpMethod.POST, "{}", ENDPOINT_URL))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
-     void givenNoOAuthToken_whenCreateAssessmentInvoked_thenUnauthorizedErrorResponseIsReturned() throws Exception {
+    void givenNoOAuthToken_whenCreateAssessmentInvoked_thenUnauthorizedErrorResponseIsReturned() throws Exception {
         mvc.perform(buildRequest(HttpMethod.POST, "{}", ENDPOINT_URL, Boolean.FALSE))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
-     void givenAnInvalidRepId_whenCreateAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
+    void givenAnInvalidRepId_whenCreateAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
         var initialMeansAssessmentRequest =
                 TestModelDataBuilder.getCreateMeansAssessmentRequest(IS_VALID);
         initialMeansAssessmentRequest.setRepId(-1000);
@@ -134,7 +134,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     }
 
     @Test
-     void givenAValidCreateMeansAssessmentRequest_whenDateCompletionCallFails_thenServerErrorResponseIsReturned()
+    void givenAValidCreateMeansAssessmentRequest_whenDateCompletionCallFails_thenServerErrorResponseIsReturned()
             throws Exception {
 
         var initialMeansAssessmentRequest =
@@ -158,7 +158,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     }
 
     @Test
-     void givenAValidCreateMeansAssessmentRequest_WhenCreateAssessmentInvoked_ThenSuccessResponseIsReturned()
+    void givenAValidCreateMeansAssessmentRequest_WhenCreateAssessmentInvoked_ThenSuccessResponseIsReturned()
             throws Exception {
 
         var initialMeansAssessmentRequest =
@@ -189,19 +189,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     }
 
     @Test
-     void givenAInvalidContent_whenUpdateAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
+    void givenAInvalidContent_whenUpdateAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
         mvc.perform(buildRequest(HttpMethod.PUT, "{}", ENDPOINT_URL))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
-     void givenNoOAuthToken_whenUpdateAssessmentInvoked_thenUnauthorizedErrorResponseIsReturned() throws Exception {
+    void givenNoOAuthToken_whenUpdateAssessmentInvoked_thenUnauthorizedErrorResponseIsReturned() throws Exception {
         mvc.perform(buildRequest(HttpMethod.PUT, "{}", ENDPOINT_URL, Boolean.FALSE))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
-     void givenAValidUpdateMeansAssessmentRequest_whenUpdateAssessmentInvoked_ThenSuccessResponseIsReturned() throws Exception {
+    void givenAValidUpdateMeansAssessmentRequest_whenUpdateAssessmentInvoked_ThenSuccessResponseIsReturned() throws Exception {
         var updateAssessmentRequest =
                 TestModelDataBuilder.getUpdateMeansAssessmentRequest(IS_VALID);
         updateAssessmentRequest.setAssessmentType(AssessmentType.FULL);
@@ -245,13 +245,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     }
 
     @Test
-     void givenAInvalidContent_whenGetOldAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
+    void givenAInvalidContent_whenGetOldAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
         mvc.perform(buildRequest(HttpMethod.GET, ENDPOINT_URL, ENDPOINT_URL, Boolean.TRUE))
                 .andExpect(status().isMethodNotAllowed());
     }
 
     @Test
-     void givenNoOAuthToken_whenGetOldAssessmentInvoked_thenUnauthorizedErrorResponseIsReturned() throws Exception {
+    void givenNoOAuthToken_whenGetOldAssessmentInvoked_thenUnauthorizedErrorResponseIsReturned() throws Exception {
         mvc.perform(buildRequest(HttpMethod.GET, ENDPOINT_URL + "/"
                         + TestModelDataBuilder.MEANS_ASSESSMENT_ID + "/" +
                         TestModelDataBuilder.MEANS_ASSESSMENT_TRANSACTION_ID, Boolean.FALSE))
@@ -260,7 +260,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
     @Test
     @Disabled("Flaky test")
-     void givenAValidFinancialAssessmentId_whenGetOldAssessmentInvoked_thenAssessmentIsReturned() throws Exception {
+    void givenAValidFinancialAssessmentId_whenGetOldAssessmentInvoked_thenAssessmentIsReturned() throws Exception {
         FinancialAssessmentDTO financialAssessmentDTO =
                 TestModelDataBuilder.getFinancialAssessmentDTO(
                         CurrentStatus.IN_PROGRESS.getStatus(),

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/MeansAssessmentIntegrationTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/MeansAssessmentIntegrationTest.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import org.junit.*;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
@@ -14,7 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -46,21 +46,18 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DirtiesContext
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @Import(CrimeMeansAssessmentTestConfiguration.class)
 @SpringBootTest(
         classes = {
                 CrimeMeansAssessmentApplication.class, MeansAssessmentResponseBuilder.class
         }, webEnvironment = DEFINED_PORT)
-public class MeansAssessmentIntegrationTest {
+ class MeansAssessmentIntegrationTest {
 
     private static final boolean IS_VALID = true;
     private static final String ENDPOINT_URL = "/api/internal/v1/assessment/means";
-
-    private MockMvc mvc;
-
     private static MockWebServer mockMaatCourtDataApi;
-
+    private MockMvc mvc;
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -70,22 +67,22 @@ public class MeansAssessmentIntegrationTest {
     @Autowired
     private FilterChainProxy springSecurityFilterChain;
 
-    @Before
-    public void setup() {
-        this.mvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext)
-                .addFilter(springSecurityFilterChain).build();
-    }
-
-    @BeforeClass
-    public static void initialiseMockWebServer() throws IOException {
+    @BeforeAll
+     static void initialiseMockWebServer() throws IOException {
         mockMaatCourtDataApi = new MockWebServer();
         mockMaatCourtDataApi.start(9999);
         mockMaatCourtDataApi.setDispatcher(MockWebServerStubs.getDispatcher());
     }
 
-    @AfterClass
-    public static void shutdownMockWebServer() throws IOException {
+    @AfterAll
+     static void shutdownMockWebServer() throws IOException {
         mockMaatCourtDataApi.shutdown();
+    }
+
+    @BeforeEach
+     void setup() {
+        this.mvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext)
+                .addFilter(springSecurityFilterChain).build();
     }
 
     private MockHttpServletRequestBuilder buildRequest(HttpMethod method, String endpointUrl, boolean withAuth) {
@@ -112,19 +109,19 @@ public class MeansAssessmentIntegrationTest {
     }
 
     @Test
-    public void givenAInvalidContent_whenCreateAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
+     void givenAInvalidContent_whenCreateAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
         mvc.perform(buildRequest(HttpMethod.POST, "{}", ENDPOINT_URL))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
-    public void givenNoOAuthToken_whenCreateAssessmentInvoked_thenUnauthorizedErrorResponseIsReturned() throws Exception {
+     void givenNoOAuthToken_whenCreateAssessmentInvoked_thenUnauthorizedErrorResponseIsReturned() throws Exception {
         mvc.perform(buildRequest(HttpMethod.POST, "{}", ENDPOINT_URL, Boolean.FALSE))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
-    public void givenAnInvalidRepId_whenCreateAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
+     void givenAnInvalidRepId_whenCreateAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
         var initialMeansAssessmentRequest =
                 TestModelDataBuilder.getCreateMeansAssessmentRequest(IS_VALID);
         initialMeansAssessmentRequest.setRepId(-1000);
@@ -137,7 +134,7 @@ public class MeansAssessmentIntegrationTest {
     }
 
     @Test
-    public void givenAValidCreateMeansAssessmentRequest_whenDateCompletionCallFails_thenServerErrorResponseIsReturned()
+     void givenAValidCreateMeansAssessmentRequest_whenDateCompletionCallFails_thenServerErrorResponseIsReturned()
             throws Exception {
 
         var initialMeansAssessmentRequest =
@@ -161,7 +158,7 @@ public class MeansAssessmentIntegrationTest {
     }
 
     @Test
-    public void givenAValidCreateMeansAssessmentRequest_WhenCreateAssessmentInvoked_ThenSuccessResponseIsReturned()
+     void givenAValidCreateMeansAssessmentRequest_WhenCreateAssessmentInvoked_ThenSuccessResponseIsReturned()
             throws Exception {
 
         var initialMeansAssessmentRequest =
@@ -192,19 +189,19 @@ public class MeansAssessmentIntegrationTest {
     }
 
     @Test
-    public void givenAInvalidContent_whenUpdateAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
+     void givenAInvalidContent_whenUpdateAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
         mvc.perform(buildRequest(HttpMethod.PUT, "{}", ENDPOINT_URL))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
-    public void givenNoOAuthToken_whenUpdateAssessmentInvoked_thenUnauthorizedErrorResponseIsReturned() throws Exception {
+     void givenNoOAuthToken_whenUpdateAssessmentInvoked_thenUnauthorizedErrorResponseIsReturned() throws Exception {
         mvc.perform(buildRequest(HttpMethod.PUT, "{}", ENDPOINT_URL, Boolean.FALSE))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
-    public void givenAValidUpdateMeansAssessmentRequest_whenUpdateAssessmentInvoked_ThenSuccessResponseIsReturned() throws Exception {
+     void givenAValidUpdateMeansAssessmentRequest_whenUpdateAssessmentInvoked_ThenSuccessResponseIsReturned() throws Exception {
         var updateAssessmentRequest =
                 TestModelDataBuilder.getUpdateMeansAssessmentRequest(IS_VALID);
         updateAssessmentRequest.setAssessmentType(AssessmentType.FULL);
@@ -248,13 +245,13 @@ public class MeansAssessmentIntegrationTest {
     }
 
     @Test
-    public void givenAInvalidContent_whenGetOldAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
+     void givenAInvalidContent_whenGetOldAssessmentInvoked_thenBadRequestErrorResponseIsReturned() throws Exception {
         mvc.perform(buildRequest(HttpMethod.GET, ENDPOINT_URL, ENDPOINT_URL, Boolean.TRUE))
                 .andExpect(status().isMethodNotAllowed());
     }
 
     @Test
-    public void givenNoOAuthToken_whenGetOldAssessmentInvoked_thenUnauthorizedErrorResponseIsReturned() throws Exception {
+     void givenNoOAuthToken_whenGetOldAssessmentInvoked_thenUnauthorizedErrorResponseIsReturned() throws Exception {
         mvc.perform(buildRequest(HttpMethod.GET, ENDPOINT_URL + "/"
                         + TestModelDataBuilder.MEANS_ASSESSMENT_ID + "/" +
                         TestModelDataBuilder.MEANS_ASSESSMENT_TRANSACTION_ID, Boolean.FALSE))
@@ -262,8 +259,8 @@ public class MeansAssessmentIntegrationTest {
     }
 
     @Test
-    @Ignore("Flaky test")
-    public void givenAValidFinancialAssessmentId_whenGetOldAssessmentInvoked_thenAssessmentIsReturned() throws Exception {
+    @Disabled("Flaky test")
+     void givenAValidFinancialAssessmentId_whenGetOldAssessmentInvoked_thenAssessmentIsReturned() throws Exception {
         FinancialAssessmentDTO financialAssessmentDTO =
                 TestModelDataBuilder.getFinancialAssessmentDTO(
                         CurrentStatus.IN_PROGRESS.getStatus(),

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/StatelessMeansAssessmentControllerTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/StatelessMeansAssessmentControllerTest.java
@@ -1,15 +1,15 @@
 package uk.gov.justice.laa.crime.meansassessment.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.model.common.ApiMeansAssessmentRequest;
@@ -36,10 +36,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.justice.laa.crime.meansassessment.util.RequestBuilderUtils.buildRequestGivenContent;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(StatelessMeansAssessmentController.class)
-public class StatelessMeansAssessmentControllerTest {
+class StatelessMeansAssessmentControllerTest {
     private static final String MEANS_ASSESSMENT_ENDPOINT_URL = "/api/internal/v2/assessment/means";
     private static final ApiMeansAssessmentRequest testRequest = TestModelDataBuilder.getApiCreateMeansAssessmentRequest(true);
     private static final DependantChild childOne = new DependantChild().withAgeRange(AgeRange.ZERO_TO_ONE).withCount(2);
@@ -57,7 +57,7 @@ public class StatelessMeansAssessmentControllerTest {
     private StatelessAssessmentService statelessAssessmentService;
 
     @Test
-    public void validRequest_success() throws Exception {
+    void validRequest_success() throws Exception {
         var assessment = buildAssessment(StatelessRequestType.BOTH);
 
         var request = new StatelessApiRequest()
@@ -77,7 +77,7 @@ public class StatelessMeansAssessmentControllerTest {
     }
 
     @Test
-    public void fullRequest_success() throws Exception {
+    void fullRequest_success() throws Exception {
         var assessment = buildAssessment(StatelessRequestType.BOTH);
 
         var request = new StatelessApiRequest()
@@ -99,13 +99,13 @@ public class StatelessMeansAssessmentControllerTest {
     }
 
     @Test
-    public void requestFailsValidation() throws Exception {
+    void requestFailsValidation() throws Exception {
         mvc.perform(buildRequestGivenContent(HttpMethod.POST, "invalid JSON", MEANS_ASSESSMENT_ENDPOINT_URL))
                 .andExpect(status().is4xxClientError());
     }
 
     @Test
-    public void requestBodyIsMissing() throws Exception {
+    void requestBodyIsMissing() throws Exception {
         mvc.perform(buildRequestGivenContent(HttpMethod.POST, "", MEANS_ASSESSMENT_ENDPOINT_URL))
                 .andExpect(status().is4xxClientError());
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/StatelessMeansAssessmentIntegrationTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/StatelessMeansAssessmentIntegrationTest.java
@@ -1,16 +1,16 @@
 package uk.gov.justice.laa.crime.meansassessment.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.security.web.FilterChainProxy;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -41,13 +41,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.justice.laa.crime.meansassessment.util.RequestBuilderUtils.buildRequestGivenContent;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @Import(CrimeMeansAssessmentTestConfiguration.class)
 @SpringBootTest(
         classes = {
                 CrimeMeansAssessmentApplication.class, MeansAssessmentResponseBuilder.class
         }, webEnvironment = DEFINED_PORT)
-public class StatelessMeansAssessmentIntegrationTest {
+class StatelessMeansAssessmentIntegrationTest {
     private static final String MEANS_ASSESSMENT_ENDPOINT_URL = "/api/internal/v2/assessment/means";
 
     private MockMvc mvc;
@@ -70,14 +70,14 @@ public class StatelessMeansAssessmentIntegrationTest {
     private static final DependantChild childOne = new DependantChild().withAgeRange(AgeRange.ZERO_TO_ONE).withCount(2);
     private static final DependantChild childTwo = new DependantChild().withAgeRange(AgeRange.FIVE_TO_SEVEN).withCount(1);
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         this.mvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext)
                 .addFilter(springSecurityFilterChain).build();
     }
 
     @Test
-    public void validJsonProducesSuccessResult() throws Exception {
+    void validJsonProducesSuccessResult() throws Exception {
         var assessment = buildAssessment(StatelessRequestType.BOTH);
 
         var request = new StatelessApiRequest()
@@ -92,7 +92,7 @@ public class StatelessMeansAssessmentIntegrationTest {
     }
 
     @Test
-    public void simplePassProducesSuccessfulResult() throws Exception {
+    void simplePassProducesSuccessfulResult() throws Exception {
         var income = new Income(IncomeType.EMPLOYMENT_INCOME, incomeAmount, incomeAmount);
         var tax = new Outgoing(OutgoingType.TAX, taxAmount, taxAmount);
         var ni = new Outgoing(OutgoingType.NATIONAL_INSURANCE, niAmount, niAmount);

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/factory/MeansAssessmentServiceFactoryTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/factory/MeansAssessmentServiceFactoryTest.java
@@ -13,19 +13,19 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest()
 @ExtendWith(SpringExtension.class)
- class MeansAssessmentServiceFactoryTest {
+class MeansAssessmentServiceFactoryTest {
 
     @Autowired
     private MeansAssessmentServiceFactory meansAssessmentServiceFactory;
 
     @Test
-     void givenInitAssessmentType_whenGetServiceIsInvoked_thenInitAssessmentServiceIsReturned() {
+    void givenInitAssessmentType_whenGetServiceIsInvoked_thenInitAssessmentServiceIsReturned() {
         assertThat(meansAssessmentServiceFactory.getService(AssessmentType.INIT))
                 .isInstanceOf(InitMeansAssessmentService.class);
     }
 
     @Test
-     void givenFullAssessmentType_whenGetServiceIsInvoked_thenFullAssessmentServiceIsReturned() {
+    void givenFullAssessmentType_whenGetServiceIsInvoked_thenFullAssessmentServiceIsReturned() {
         assertThat(meansAssessmentServiceFactory.getService(AssessmentType.FULL))
                 .isInstanceOf(FullMeansAssessmentService.class);
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/factory/MeansAssessmentServiceFactoryTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/factory/MeansAssessmentServiceFactoryTest.java
@@ -1,10 +1,10 @@
 package uk.gov.justice.laa.crime.meansassessment.factory;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.justice.laa.crime.meansassessment.service.FullMeansAssessmentService;
 import uk.gov.justice.laa.crime.meansassessment.service.InitMeansAssessmentService;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.AssessmentType;
@@ -12,20 +12,20 @@ import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.AssessmentType;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest()
-@RunWith(SpringRunner.class)
-public class MeansAssessmentServiceFactoryTest {
+@ExtendWith(SpringExtension.class)
+ class MeansAssessmentServiceFactoryTest {
 
     @Autowired
     private MeansAssessmentServiceFactory meansAssessmentServiceFactory;
 
     @Test
-    public void givenInitAssessmentType_whenGetServiceIsInvoked_thenInitAssessmentServiceIsReturned() {
+     void givenInitAssessmentType_whenGetServiceIsInvoked_thenInitAssessmentServiceIsReturned() {
         assertThat(meansAssessmentServiceFactory.getService(AssessmentType.INIT))
                 .isInstanceOf(InitMeansAssessmentService.class);
     }
 
     @Test
-    public void givenFullAssessmentType_whenGetServiceIsInvoked_thenFullAssessmentServiceIsReturned() {
+     void givenFullAssessmentType_whenGetServiceIsInvoked_thenFullAssessmentServiceIsReturned() {
         assertThat(meansAssessmentServiceFactory.getService(AssessmentType.FULL))
                 .isInstanceOf(FullMeansAssessmentService.class);
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCompletionServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCompletionServiceTest.java
@@ -1,12 +1,12 @@
 package uk.gov.justice.laa.crime.meansassessment.service;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentDTO;
 import uk.gov.justice.laa.crime.meansassessment.dto.maatcourtdata.DateCompletionRequestDTO;
@@ -20,12 +20,11 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
-public class AssessmentCompletionServiceTest {
+@ExtendWith(MockitoExtension.class)
+class AssessmentCompletionServiceTest {
 
-    private MeansAssessmentDTO assessment;
     private final String LAA_TRANSACTION_ID = "laa-transaction-id";
-
+    private MeansAssessmentDTO assessment;
     @Spy
     @InjectMocks
     private AssessmentCompletionService assessmentCompletionService;
@@ -34,13 +33,13 @@ public class AssessmentCompletionServiceTest {
     private MaatCourtDataService maatCourtDataService;
 
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         assessment = TestModelDataBuilder.getMeansAssessmentDTO();
     }
 
     @Test
-    public void givenNullExistingCompletionDate_whenIsFullUpdateRequiredIsInvoked_thenReturnTrue() {
+    void givenNullExistingCompletionDate_whenIsFullUpdateRequiredIsInvoked_thenReturnTrue() {
         when(maatCourtDataService.getFinancialAssessment(anyInt(), anyString()))
                 .thenReturn(FinancialAssessmentDTO.builder().build());
 
@@ -49,7 +48,7 @@ public class AssessmentCompletionServiceTest {
     }
 
     @Test
-    public void givenExistingCompletionDate_whenIsFullUpdateRequiredIsInvoked_thenReturnFalse() {
+    void givenExistingCompletionDate_whenIsFullUpdateRequiredIsInvoked_thenReturnFalse() {
         when(maatCourtDataService.getFinancialAssessment(anyInt(), anyString()))
                 .thenReturn(
                         FinancialAssessmentDTO
@@ -63,7 +62,7 @@ public class AssessmentCompletionServiceTest {
     }
 
     @Test
-    public void givenNullFinancialAssessmentId_whenIsFullUpdateRequiredIsInvoked_thenReturnTrue() {
+    void givenNullFinancialAssessmentId_whenIsFullUpdateRequiredIsInvoked_thenReturnTrue() {
         assessment.getMeansAssessment().setFinancialAssessmentId(null);
         boolean result = assessmentCompletionService.isFullUpdateRequired(
                 assessment, LAA_TRANSACTION_ID
@@ -72,7 +71,7 @@ public class AssessmentCompletionServiceTest {
     }
 
     @Test
-    public void givenAssessment_whenUpdateApplicationCompletionDateIsInvoked_thenCompletionDateIsPersisted() {
+    void givenAssessment_whenUpdateApplicationCompletionDateIsInvoked_thenCompletionDateIsPersisted() {
         when(maatCourtDataService.updateCompletionDate(any(DateCompletionRequestDTO.class), anyString()))
                 .thenReturn(TestModelDataBuilder.getRepOrderDTO());
 
@@ -81,40 +80,40 @@ public class AssessmentCompletionServiceTest {
     }
 
     @Test
-    public void givenPassedInitAssessmentResult_whenIsInitAssessmentCompleteIsInvoked_thenReturnTrue() {
+    void givenPassedInitAssessmentResult_whenIsInitAssessmentCompleteIsInvoked_thenReturnTrue() {
         assessment.setInitAssessmentResult(InitAssessmentResult.PASS);
         assertThat(assessmentCompletionService.isInitAssessmentComplete(assessment)).isTrue();
     }
 
     @Test
-    public void givenFullInitAssessmentResult_whenIsInitAssessmentCompleteIsInvoked_thenReturnFalse() {
+    void givenFullInitAssessmentResult_whenIsInitAssessmentCompleteIsInvoked_thenReturnFalse() {
         assessment.setInitAssessmentResult(InitAssessmentResult.FULL);
         assertThat(Boolean.FALSE).isEqualTo(assessmentCompletionService.isInitAssessmentComplete(assessment));
     }
 
     @Test
-    public void givenFailedSummaryOnly_whenIsInitAssessmentCompleteIsInvoked_thenReturnTrue() {
+    void givenFailedSummaryOnly_whenIsInitAssessmentCompleteIsInvoked_thenReturnTrue() {
         assessment.setInitAssessmentResult(InitAssessmentResult.FAIL);
         assessment.getMeansAssessment().setCaseType(CaseType.SUMMARY_ONLY);
         assertThat(assessmentCompletionService.isInitAssessmentComplete(assessment)).isTrue();
     }
 
     @Test
-    public void givenFailedCommital_whenIsInitAssessmentCompleteIsInvoked_thenReturnTrue() {
+    void givenFailedCommital_whenIsInitAssessmentCompleteIsInvoked_thenReturnTrue() {
         assessment.setInitAssessmentResult(InitAssessmentResult.FAIL);
         assessment.getMeansAssessment().setCaseType(CaseType.COMMITAL);
         assertThat(Boolean.TRUE).isEqualTo(assessmentCompletionService.isInitAssessmentComplete(assessment));
     }
 
     @Test
-    public void givenFailedIndictable_whenIsInitAssessmentCompleteIsInvoked_thenReturnFalse() {
+    void givenFailedIndictable_whenIsInitAssessmentCompleteIsInvoked_thenReturnFalse() {
         assessment.setInitAssessmentResult(InitAssessmentResult.FAIL);
         assessment.getMeansAssessment().setCaseType(CaseType.INDICTABLE);
         assertThat(assessmentCompletionService.isInitAssessmentComplete(assessment)).isFalse();
     }
 
     @Test
-    public void givenFailedEitherWayAndCommittedForTrialsInMagsOutcome_whenIsInitAssessmentCompleteIsInvoked_thenReturnTrue() {
+    void givenFailedEitherWayAndCommittedForTrialsInMagsOutcome_whenIsInitAssessmentCompleteIsInvoked_thenReturnTrue() {
         assessment.setInitAssessmentResult(InitAssessmentResult.FAIL);
         assessment.getMeansAssessment().setCaseType(CaseType.EITHER_WAY);
         assessment.getMeansAssessment().setMagCourtOutcome(MagCourtOutcome.COMMITTED_FOR_TRIAL);
@@ -122,7 +121,7 @@ public class AssessmentCompletionServiceTest {
     }
 
     @Test
-    public void givenFailedEitherWayAndAppealToCCMagsOutcome_whenIsInitAssessmentCompleteIsInvoked_thenReturnFalse() {
+    void givenFailedEitherWayAndAppealToCCMagsOutcome_whenIsInitAssessmentCompleteIsInvoked_thenReturnFalse() {
         assessment.setInitAssessmentResult(InitAssessmentResult.FAIL);
         assessment.getMeansAssessment().setCaseType(CaseType.EITHER_WAY);
         assessment.getMeansAssessment().setMagCourtOutcome(MagCourtOutcome.APPEAL_TO_CC);
@@ -130,7 +129,7 @@ public class AssessmentCompletionServiceTest {
     }
 
     @Test
-    public void givenIncompleteAssessment_whenExecuteIsInvoked_thenCompletionDateIsNotUpdated() {
+    void givenIncompleteAssessment_whenExecuteIsInvoked_thenCompletionDateIsNotUpdated() {
         assessment.getMeansAssessment().setAssessmentStatus(CurrentStatus.IN_PROGRESS);
         assessmentCompletionService.execute(assessment, LAA_TRANSACTION_ID);
         verify(maatCourtDataService, never())
@@ -138,7 +137,7 @@ public class AssessmentCompletionServiceTest {
     }
 
     @Test
-    public void givenCompleteInitAssessment_whenExecuteIsInvoked_thenCompletionDateIsUpdated() {
+    void givenCompleteInitAssessment_whenExecuteIsInvoked_thenCompletionDateIsUpdated() {
         doReturn(true)
                 .when(assessmentCompletionService).isInitAssessmentComplete(any(MeansAssessmentDTO.class));
 
@@ -150,7 +149,7 @@ public class AssessmentCompletionServiceTest {
     }
 
     @Test
-    public void givenCompleteFullAssessment_whenExecuteIsInvoked_thenCompletionDateIsUpdated() {
+    void givenCompleteFullAssessment_whenExecuteIsInvoked_thenCompletionDateIsUpdated() {
         assessment.getMeansAssessment().setAssessmentType(AssessmentType.FULL);
         doReturn(true)
                 .when(assessmentCompletionService).isFullUpdateRequired(any(MeansAssessmentDTO.class), anyString());

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaChildWeightingServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaChildWeightingServiceTest.java
@@ -1,10 +1,10 @@
 package uk.gov.justice.laa.crime.meansassessment.service;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.exception.ValidationException;
 import uk.gov.justice.laa.crime.meansassessment.model.common.ApiAssessmentChildWeighting;
@@ -17,16 +17,16 @@ import java.util.List;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-@RunWith(MockitoJUnitRunner.class)
-public class AssessmentCriteriaChildWeightingServiceTest {
+@ExtendWith(MockitoExtension.class)
+class AssessmentCriteriaChildWeightingServiceTest {
 
     @InjectMocks
     private AssessmentCriteriaChildWeightingService criteriaChildWeightingService;
 
     private AssessmentCriteriaEntity assessmentCriteria;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         assessmentCriteria = TestModelDataBuilder.getAssessmentCriteriaEntityWithChildWeightings(
                 new BigDecimal[]{
                         BigDecimal.valueOf(0.15), BigDecimal.valueOf(0.35)
@@ -36,7 +36,7 @@ public class AssessmentCriteriaChildWeightingServiceTest {
     }
 
     @Test
-    public void givenIncorrectNumberOfChildWeightings_whenGetTotalChildWeightingIsInvoked_thenThrowsException() {
+    void givenIncorrectNumberOfChildWeightings_whenGetTotalChildWeightingIsInvoked_thenThrowsException() {
         List<ApiAssessmentChildWeighting> childWeightings = new ArrayList<>();
         assertThatThrownBy(
                 () -> criteriaChildWeightingService.getTotalChildWeighting(childWeightings, assessmentCriteria)
@@ -46,7 +46,7 @@ public class AssessmentCriteriaChildWeightingServiceTest {
     }
 
     @Test
-    public void givenMissingChildWeighting_whenGetTotalChildWeightingIsInvoked_thenThrowsException() {
+    void givenMissingChildWeighting_whenGetTotalChildWeightingIsInvoked_thenThrowsException() {
         List<ApiAssessmentChildWeighting> childWeightings = TestModelDataBuilder.getAssessmentChildWeightings();
         childWeightings.get(0).setChildWeightingId(0);
         assertThatThrownBy(
@@ -55,7 +55,7 @@ public class AssessmentCriteriaChildWeightingServiceTest {
     }
 
     @Test
-    public void givenValidChildWeightings_whenGetTotalChildWeightingIsInvoked_thenReturnTotalWeighting() {
+    void givenValidChildWeightings_whenGetTotalChildWeightingIsInvoked_thenReturnTotalWeighting() {
         BigDecimal expectedWeighting = BigDecimal.valueOf(0.85);
         List<ApiAssessmentChildWeighting> childWeightings = TestModelDataBuilder.getAssessmentChildWeightings();
         assertThat(criteriaChildWeightingService.getTotalChildWeighting(childWeightings, assessmentCriteria)).isEqualTo(expectedWeighting);

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaDetailServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaDetailServiceTest.java
@@ -1,18 +1,18 @@
 package uk.gov.justice.laa.crime.meansassessment.service;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.repository.AssessmentCriteriaDetailRepository;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
-public class AssessmentCriteriaDetailServiceTest {
+@ExtendWith(MockitoExtension.class)
+ class AssessmentCriteriaDetailServiceTest {
 
     @InjectMocks
     private AssessmentCriteriaDetailService assessmentCriteriaDetailService;
@@ -21,7 +21,7 @@ public class AssessmentCriteriaDetailServiceTest {
     private AssessmentCriteriaDetailRepository assessmentCriteriaDetailRepository;
 
     @Test
-    public void testAssessmentCriteriaDetailService_whenGetAssessmentCriteriaDetailByIdInvoked_shouldSuccess() {
+     void testAssessmentCriteriaDetailService_whenGetAssessmentCriteriaDetailByIdInvoked_shouldSuccess() {
         assessmentCriteriaDetailService.getAssessmentCriteriaDetailById(41681827);
         verify(assessmentCriteriaDetailRepository, times(1)).findById(any());
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaDetailServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaDetailServiceTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
- class AssessmentCriteriaDetailServiceTest {
+class AssessmentCriteriaDetailServiceTest {
 
     @InjectMocks
     private AssessmentCriteriaDetailService assessmentCriteriaDetailService;
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
     private AssessmentCriteriaDetailRepository assessmentCriteriaDetailRepository;
 
     @Test
-     void testAssessmentCriteriaDetailService_whenGetAssessmentCriteriaDetailByIdInvoked_shouldSuccess() {
+    void testAssessmentCriteriaDetailService_whenGetAssessmentCriteriaDetailByIdInvoked_shouldSuccess() {
         assessmentCriteriaDetailService.getAssessmentCriteriaDetailById(41681827);
         verify(assessmentCriteriaDetailRepository, times(1)).findById(any());
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCriteriaServiceTest.java
@@ -2,13 +2,13 @@ package uk.gov.justice.laa.crime.meansassessment.service;
 
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.ThrowableAssert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.exception.AssessmentCriteriaNotFoundException;
 import uk.gov.justice.laa.crime.meansassessment.exception.ValidationException;
@@ -30,8 +30,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class AssessmentCriteriaServiceTest {
+@ExtendWith(MockitoExtension.class)
+class AssessmentCriteriaServiceTest {
 
     private static final int VALID_ASSESSMENT_CRITERIA_ID = 1000;
     private AssessmentCriteriaEntity assessmentCriteriaEntity;
@@ -49,14 +49,14 @@ public class AssessmentCriteriaServiceTest {
     @Mock
     private CaseTypeAssessmentCriteriaDetailValueRepository caseTypeAssessmentCriteriaDetailValueRepository;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         assessmentCriteriaEntity = TestModelDataBuilder.getAssessmentCriteriaEntityWithDetails();
         assessmentCriteriaEntity.setId(VALID_ASSESSMENT_CRITERIA_ID);
     }
 
     @Test
-    public void givenValidDateWithPartnerAndNoContraryInterest_WhenGetAssessmentCriteriaIsInvoked_ThenAssessmentCriteriaShouldBeReturnedWithPartnerWeightingFactor() {
+    void givenValidDateWithPartnerAndNoContraryInterest_WhenGetAssessmentCriteriaIsInvoked_ThenAssessmentCriteriaShouldBeReturnedWithPartnerWeightingFactor() {
         when(assessmentCriteriaRepository.findAssessmentCriteriaForDate(any(LocalDateTime.class)))
                 .thenReturn(assessmentCriteriaEntity);
 
@@ -68,7 +68,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenValidDateAndNoPartner_WhenGetAssessmentCriteriaIsInvoked_ThenAssessmentCriteriaShouldBeReturnedWithZeroedPartnerWeightingFactor() {
+    void givenValidDateAndNoPartner_WhenGetAssessmentCriteriaIsInvoked_ThenAssessmentCriteriaShouldBeReturnedWithZeroedPartnerWeightingFactor() {
         when(assessmentCriteriaRepository.findAssessmentCriteriaForDate(any(LocalDateTime.class)))
                 .thenReturn(assessmentCriteriaEntity);
 
@@ -81,7 +81,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenValidDateWithPartnerAndContraryInterest_WhenGetAssessmentCriteriaIsInvoked_ThenAssessmentCriteriaShouldBeReturnedWithPartnerWeightingFactor() {
+    void givenValidDateWithPartnerAndContraryInterest_WhenGetAssessmentCriteriaIsInvoked_ThenAssessmentCriteriaShouldBeReturnedWithPartnerWeightingFactor() {
         when(assessmentCriteriaRepository.findAssessmentCriteriaForDate(any(LocalDateTime.class)))
                 .thenReturn(assessmentCriteriaEntity);
 
@@ -94,7 +94,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenValidDateWithoutPartnerAndContraryInterest_WhenGetAssessmentCriteriaIsInvoked_ThenAssessmentCriteriaShouldBeReturnedWithZeroedPartnerWeightingFactor() {
+    void givenValidDateWithoutPartnerAndContraryInterest_WhenGetAssessmentCriteriaIsInvoked_ThenAssessmentCriteriaShouldBeReturnedWithZeroedPartnerWeightingFactor() {
         when(assessmentCriteriaRepository.findAssessmentCriteriaForDate(any(LocalDateTime.class)))
                 .thenReturn(assessmentCriteriaEntity);
 
@@ -107,7 +107,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenInvalidDateWithPartnerAndNoContraryInterest_WhenGetAssessmentCriteriaIsInvoked_ThenExceptionIsThrown() throws AssessmentCriteriaNotFoundException {
+    void givenInvalidDateWithPartnerAndNoContraryInterest_WhenGetAssessmentCriteriaIsInvoked_ThenExceptionIsThrown() throws AssessmentCriteriaNotFoundException {
         when(assessmentCriteriaRepository.findAssessmentCriteriaForDate(any(LocalDateTime.class))).thenReturn(null);
 
         LocalDateTime criteriaDate = TestModelDataBuilder.TEST_DATE_FROM.minusYears(100);
@@ -119,7 +119,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenValidFrequency_whenCheckCriteriaDetailFrequencyIsInvoked_thenDoesNothing() {
+    void givenValidFrequency_whenCheckCriteriaDetailFrequencyIsInvoked_thenDoesNothing() {
         when(assessmentCriteriaDetailFrequencyRepository.findByAssessmentCriteriaDetailAndFrequency(
                         any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
                 )
@@ -129,7 +129,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenInvalidFrequency_whenCheckCriteriaDetailFrequencyIsInvoked_thenExceptionIsThrown() {
+    void givenInvalidFrequency_whenCheckCriteriaDetailFrequencyIsInvoked_thenExceptionIsThrown() {
         when(assessmentCriteriaDetailFrequencyRepository.findByAssessmentCriteriaDetailAndFrequency(
                         any(AssessmentCriteriaDetailEntity.class), any(Frequency.class)
                 )
@@ -142,7 +142,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenDetailWithIncorrectId_whenCheckAssessmentDetailIsInvoked_thenExceptionIsThrown() {
+    void givenDetailWithIncorrectId_whenCheckAssessmentDetailIsInvoked_thenExceptionIsThrown() {
         String section = TestModelDataBuilder.TEST_SECTION;
         ApiAssessmentDetail detail = TestModelDataBuilder.getApiAssessmentDetails().get(0);
         detail.setCriteriaDetailId(0);
@@ -160,7 +160,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenDetailWithIncorrectSection_whenCheckAssessmentDetailIsInvoked_thenExceptionIsThrown() {
+    void givenDetailWithIncorrectSection_whenCheckAssessmentDetailIsInvoked_thenExceptionIsThrown() {
         String section = "BAD_SECTION";
         ApiAssessmentDetail detail = TestModelDataBuilder.getApiAssessmentDetails().get(0);
 
@@ -179,7 +179,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenApplicantFrequency_whenCheckAssessmentDetailIsInvoked_thenValidateApplicantFrequency() {
+    void givenApplicantFrequency_whenCheckAssessmentDetailIsInvoked_thenValidateApplicantFrequency() {
         String section = TestModelDataBuilder.TEST_SECTION;
         ApiAssessmentDetail detail = TestModelDataBuilder.getApiAssessmentDetails().get(0);
 
@@ -192,7 +192,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenPartnerFrequency_whenCheckAssessmentDetailIsInvoked_thenValidatePartnerFrequency() {
+    void givenPartnerFrequency_whenCheckAssessmentDetailIsInvoked_thenValidatePartnerFrequency() {
         String section = TestModelDataBuilder.TEST_SECTION;
         ApiAssessmentDetail detail = TestModelDataBuilder.getApiAssessmentDetails(true).get(0);
 
@@ -206,7 +206,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenAppealCostsCriteriaDetailIsNull_whenCheckAssessmentDetailIsInvoked_thenDoNothing() {
+    void givenAppealCostsCriteriaDetailIsNull_whenCheckAssessmentDetailIsInvoked_thenDoNothing() {
         String section = TestModelDataBuilder.TEST_SECTION;
         ApiAssessmentDetail detail = TestModelDataBuilder.getApiAssessmentDetails(true).get(0);
 
@@ -223,7 +223,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenAppealCostsCriteriaDetailWithCorrectAmounts_whenCheckAssessmentDetailIsInvoked_thenDoNothing() {
+    void givenAppealCostsCriteriaDetailWithCorrectAmounts_whenCheckAssessmentDetailIsInvoked_thenDoNothing() {
         String section = TestModelDataBuilder.TEST_SECTION;
         ApiAssessmentDetail detail = TestModelDataBuilder.getApiAssessmentDetails(true).get(0);
 
@@ -240,7 +240,7 @@ public class AssessmentCriteriaServiceTest {
     }
 
     @Test
-    public void givenAppealCostsCriteriaDetailWithIncorrectAmounts_whenCheckAssessmentDetailIsInvoked_thenThrowsException() {
+    void givenAppealCostsCriteriaDetailWithIncorrectAmounts_whenCheckAssessmentDetailIsInvoked_thenThrowsException() {
         String section = TestModelDataBuilder.TEST_SECTION;
         ApiAssessmentDetail detail = TestModelDataBuilder.getApiAssessmentDetails(true).get(0);
 

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/BaseMeansAssessmentServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/BaseMeansAssessmentServiceTest.java
@@ -1,10 +1,10 @@
 package uk.gov.justice.laa.crime.meansassessment.service;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
 import uk.gov.justice.laa.crime.meansassessment.model.common.ApiAssessmentDetail;
@@ -19,59 +19,49 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@RunWith(MockitoJUnitRunner.class)
-public class BaseMeansAssessmentServiceTest {
+@ExtendWith(MockitoExtension.class)
+ class BaseMeansAssessmentServiceTest {
 
-    @Mock
-    private AssessmentCriteriaService assessmentCriteriaService;
-
-    private MockConcreteClass mockAssessmentService;
-
-    private MeansAssessmentRequestDTO meansAssessment;
-
+     static final BigDecimal EXPECTED_TOTAL_AMOUNT = new BigDecimal("120.00");
     private final AssessmentCriteriaEntity assessmentCriteria =
             TestModelDataBuilder.getAssessmentCriteriaEntityWithDetails();
+    @Mock
+    private AssessmentCriteriaService assessmentCriteriaService;
+    private MockConcreteClass mockAssessmentService;
+    private MeansAssessmentRequestDTO meansAssessment;
 
-    public static final BigDecimal EXPECTED_TOTAL_AMOUNT = new BigDecimal("120.00");
-
-    private class MockConcreteClass extends BaseMeansAssessmentService {
-        public MockConcreteClass(AssessmentCriteriaService assessmentCriteriaService) {
-            super(assessmentCriteriaService);
-        }
-    }
-
-    @Before
-    public void setup() {
+    @BeforeEach
+     void setup() {
         mockAssessmentService = new MockConcreteClass(assessmentCriteriaService);
         meansAssessment = TestModelDataBuilder.getMeansAssessmentRequestDTO(true);
     }
 
     @Test
-    public void givenNullAmount_whenCalculateDetailTotalIsInvoked_thenTotalIsZero() {
+     void givenNullAmount_whenCalculateDetailTotalIsInvoked_thenTotalIsZero() {
         BigDecimal total = mockAssessmentService.calculateDetailTotal(null, Frequency.FOUR_WEEKLY);
         assertThat(total).isEqualTo(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
     }
 
     @Test
-    public void givenFrequencyIsNull_whenCalculateDetailTotalIsInvoked_thenTotalIsZero() {
+     void givenFrequencyIsNull_whenCalculateDetailTotalIsInvoked_thenTotalIsZero() {
         BigDecimal total = mockAssessmentService.calculateDetailTotal(BigDecimal.TEN, null);
         assertThat(total).isEqualTo(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
     }
 
     @Test
-    public void givenZeroAmount_whenCalculateDetailTotalIsInvoked_thenTotalIsZero() {
+     void givenZeroAmount_whenCalculateDetailTotalIsInvoked_thenTotalIsZero() {
         BigDecimal total = mockAssessmentService.calculateDetailTotal(BigDecimal.ZERO, Frequency.FOUR_WEEKLY);
         assertThat(total).isEqualTo(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
     }
 
     @Test
-    public void givenValidAmountAndFrequency_whenCalculateDetailTotalIsInvoked_thenCorrectTotalIsCalculated() {
+     void givenValidAmountAndFrequency_whenCalculateDetailTotalIsInvoked_thenCorrectTotalIsCalculated() {
         BigDecimal total = mockAssessmentService.calculateDetailTotal(BigDecimal.TEN, Frequency.MONTHLY);
         assertThat(total).isEqualTo(EXPECTED_TOTAL_AMOUNT);
     }
 
     @Test
-    public void givenSingleSectionSingleDetailNoPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
+     void givenSingleSectionSingleDetailNoPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
         BigDecimal annualTotal = mockAssessmentService.calculateSummariesTotal(meansAssessment, assessmentCriteria);
         assertThat(annualTotal).isEqualTo(
                 TestModelDataBuilder.TEST_APPLICANT_VALUE.multiply(
@@ -81,7 +71,7 @@ public class BaseMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenSingleSectionTwoDetailNoPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
+     void givenSingleSectionTwoDetailNoPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
         ApiAssessmentSectionSummary section = meansAssessment.getSectionSummaries().get(0);
         section.getAssessmentDetails().add(
                 new ApiAssessmentDetail()
@@ -101,7 +91,7 @@ public class BaseMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenSingleSectionSingleDetailWithPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
+     void givenSingleSectionSingleDetailWithPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
         ApiAssessmentSectionSummary section = new ApiAssessmentSectionSummary()
                 .withAssessmentDetails(
                         new ArrayList<>(
@@ -117,7 +107,7 @@ public class BaseMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenSingleSectionTwoDetailWithPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
+     void givenSingleSectionTwoDetailWithPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
         ApiAssessmentSectionSummary section = meansAssessment.getSectionSummaries().get(0);
         section.getAssessmentDetails().add(
                 new ApiAssessmentDetail()
@@ -139,7 +129,7 @@ public class BaseMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenTwoSectionTwoDetailNoPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
+     void givenTwoSectionTwoDetailNoPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
         meansAssessment.setSectionSummaries(TestModelDataBuilder.getAssessmentSummaries());
         BigDecimal annualTotal = mockAssessmentService.calculateSummariesTotal(meansAssessment, assessmentCriteria);
         BigDecimal expected = TestModelDataBuilder.TEST_APPLICANT_VALUE.multiply(
@@ -150,7 +140,7 @@ public class BaseMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenTwoSectionTwoDetailWithPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
+     void givenTwoSectionTwoDetailWithPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
         meansAssessment.setSectionSummaries(TestModelDataBuilder.getAssessmentSummaries());
 
         List<ApiAssessmentDetail> section =
@@ -168,6 +158,12 @@ public class BaseMeansAssessmentServiceTest {
                 .setScale(2, RoundingMode.HALF_UP);
 
         assertThat(summariesTotal).isEqualTo(expected);
+    }
+
+    private class MockConcreteClass extends BaseMeansAssessmentService {
+         MockConcreteClass(AssessmentCriteriaService assessmentCriteriaService) {
+            super(assessmentCriteriaService);
+        }
     }
 
 }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/BaseMeansAssessmentServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/BaseMeansAssessmentServiceTest.java
@@ -20,9 +20,9 @@ import java.util.List;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @ExtendWith(MockitoExtension.class)
- class BaseMeansAssessmentServiceTest {
+class BaseMeansAssessmentServiceTest {
 
-     static final BigDecimal EXPECTED_TOTAL_AMOUNT = new BigDecimal("120.00");
+    static final BigDecimal EXPECTED_TOTAL_AMOUNT = new BigDecimal("120.00");
     private final AssessmentCriteriaEntity assessmentCriteria =
             TestModelDataBuilder.getAssessmentCriteriaEntityWithDetails();
     @Mock
@@ -31,37 +31,37 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     private MeansAssessmentRequestDTO meansAssessment;
 
     @BeforeEach
-     void setup() {
+    void setup() {
         mockAssessmentService = new MockConcreteClass(assessmentCriteriaService);
         meansAssessment = TestModelDataBuilder.getMeansAssessmentRequestDTO(true);
     }
 
     @Test
-     void givenNullAmount_whenCalculateDetailTotalIsInvoked_thenTotalIsZero() {
+    void givenNullAmount_whenCalculateDetailTotalIsInvoked_thenTotalIsZero() {
         BigDecimal total = mockAssessmentService.calculateDetailTotal(null, Frequency.FOUR_WEEKLY);
         assertThat(total).isEqualTo(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
     }
 
     @Test
-     void givenFrequencyIsNull_whenCalculateDetailTotalIsInvoked_thenTotalIsZero() {
+    void givenFrequencyIsNull_whenCalculateDetailTotalIsInvoked_thenTotalIsZero() {
         BigDecimal total = mockAssessmentService.calculateDetailTotal(BigDecimal.TEN, null);
         assertThat(total).isEqualTo(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
     }
 
     @Test
-     void givenZeroAmount_whenCalculateDetailTotalIsInvoked_thenTotalIsZero() {
+    void givenZeroAmount_whenCalculateDetailTotalIsInvoked_thenTotalIsZero() {
         BigDecimal total = mockAssessmentService.calculateDetailTotal(BigDecimal.ZERO, Frequency.FOUR_WEEKLY);
         assertThat(total).isEqualTo(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
     }
 
     @Test
-     void givenValidAmountAndFrequency_whenCalculateDetailTotalIsInvoked_thenCorrectTotalIsCalculated() {
+    void givenValidAmountAndFrequency_whenCalculateDetailTotalIsInvoked_thenCorrectTotalIsCalculated() {
         BigDecimal total = mockAssessmentService.calculateDetailTotal(BigDecimal.TEN, Frequency.MONTHLY);
         assertThat(total).isEqualTo(EXPECTED_TOTAL_AMOUNT);
     }
 
     @Test
-     void givenSingleSectionSingleDetailNoPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
+    void givenSingleSectionSingleDetailNoPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
         BigDecimal annualTotal = mockAssessmentService.calculateSummariesTotal(meansAssessment, assessmentCriteria);
         assertThat(annualTotal).isEqualTo(
                 TestModelDataBuilder.TEST_APPLICANT_VALUE.multiply(
@@ -71,7 +71,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenSingleSectionTwoDetailNoPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
+    void givenSingleSectionTwoDetailNoPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
         ApiAssessmentSectionSummary section = meansAssessment.getSectionSummaries().get(0);
         section.getAssessmentDetails().add(
                 new ApiAssessmentDetail()
@@ -91,7 +91,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenSingleSectionSingleDetailWithPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
+    void givenSingleSectionSingleDetailWithPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
         ApiAssessmentSectionSummary section = new ApiAssessmentSectionSummary()
                 .withAssessmentDetails(
                         new ArrayList<>(
@@ -107,7 +107,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenSingleSectionTwoDetailWithPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
+    void givenSingleSectionTwoDetailWithPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
         ApiAssessmentSectionSummary section = meansAssessment.getSectionSummaries().get(0);
         section.getAssessmentDetails().add(
                 new ApiAssessmentDetail()
@@ -129,7 +129,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenTwoSectionTwoDetailNoPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
+    void givenTwoSectionTwoDetailNoPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
         meansAssessment.setSectionSummaries(TestModelDataBuilder.getAssessmentSummaries());
         BigDecimal annualTotal = mockAssessmentService.calculateSummariesTotal(meansAssessment, assessmentCriteria);
         BigDecimal expected = TestModelDataBuilder.TEST_APPLICANT_VALUE.multiply(
@@ -140,7 +140,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenTwoSectionTwoDetailWithPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
+    void givenTwoSectionTwoDetailWithPartner_whenCalculateSummariesTotalIsInvoked_thenCorrectTotalIsCalculated() {
         meansAssessment.setSectionSummaries(TestModelDataBuilder.getAssessmentSummaries());
 
         List<ApiAssessmentDetail> section =
@@ -161,7 +161,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     private class MockConcreteClass extends BaseMeansAssessmentService {
-         MockConcreteClass(AssessmentCriteriaService assessmentCriteriaService) {
+        MockConcreteClass(AssessmentCriteriaService assessmentCriteriaService) {
             super(assessmentCriteriaService);
         }
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityServiceTest.java
@@ -1,14 +1,15 @@
 package uk.gov.justice.laa.crime.meansassessment.service;
 
-import org.assertj.core.api.JUnitSoftAssertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
 import uk.gov.justice.laa.crime.meansassessment.dto.maatcourtdata.FinancialAssessmentDTO;
@@ -25,8 +26,11 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class CrownCourtEligibilityServiceTest {
+@ExtendWith({MockitoExtension.class, SoftAssertionsExtension.class})
+class CrownCourtEligibilityServiceTest {
+
+    @InjectSoftAssertions
+    private SoftAssertions softly;
 
     @Mock
     private MaatCourtDataService maatCourtDataService;
@@ -34,8 +38,6 @@ public class CrownCourtEligibilityServiceTest {
     @InjectMocks
     private CrownCourtEligibilityService crownCourtEligibilityService;
 
-    @Rule
-    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
 
     private MeansAssessmentRequestDTO requestDTO;
 
@@ -43,8 +45,8 @@ public class CrownCourtEligibilityServiceTest {
 
     private RepOrderDTO repOrderDTO;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         requestDTO = TestModelDataBuilder.getMeansAssessmentRequestDTO(true);
         repOrderDTO = TestModelDataBuilder.getRepOrderDTOWithAssessments(new ArrayList<>(List.of(financialAssessment)));
 
@@ -52,14 +54,14 @@ public class CrownCourtEligibilityServiceTest {
                 .thenReturn(repOrderDTO);
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         financialAssessment = TestModelDataBuilder.getFinancialAssessmentDTO();
         repOrderDTO = TestModelDataBuilder.getRepOrderDTOWithAssessments(new ArrayList<>(List.of(financialAssessment)));
     }
 
     @Test
-    public void givenIndictableSentForTrialAndNoPreviousAssessments_whenIsEligibilityCheckRequiredIsInvoked_thenCorrectResultIsReturned() {
+    void givenIndictableSentForTrialAndNoPreviousAssessments_whenIsEligibilityCheckRequiredIsInvoked_thenCorrectResultIsReturned() {
         requestDTO.setCaseType(CaseType.INDICTABLE);
         requestDTO.setMagCourtOutcome(MagCourtOutcome.SENT_FOR_TRIAL);
         softly.assertThat(crownCourtEligibilityService.isEligibilityCheckRequired(requestDTO)).isFalse();
@@ -69,7 +71,7 @@ public class CrownCourtEligibilityServiceTest {
     }
 
     @Test
-    public void givenCCAlreadySentForTrialAndNoPreviousAssessments_whenIsEligibilityCheckRequiredIsInvoked_thenCorrectResultIsReturned() {
+    void givenCCAlreadySentForTrialAndNoPreviousAssessments_whenIsEligibilityCheckRequiredIsInvoked_thenCorrectResultIsReturned() {
         requestDTO.setCaseType(CaseType.CC_ALREADY);
         requestDTO.setMagCourtOutcome(MagCourtOutcome.SENT_FOR_TRIAL);
         softly.assertThat(crownCourtEligibilityService.isEligibilityCheckRequired(requestDTO)).isFalse();
@@ -79,13 +81,13 @@ public class CrownCourtEligibilityServiceTest {
     }
 
     @Test
-    public void givenEWCommittedAndFirstAssessment_whenIsEligibilityCheckRequiredIsInvoked_thenCorrectResultIsReturned() {
+    void givenEWCommittedAndFirstAssessment_whenIsEligibilityCheckRequiredIsInvoked_thenCorrectResultIsReturned() {
         financialAssessment.setNewWorkReason(NewWorkReason.FMA.getCode());
         assertThat(crownCourtEligibilityService.isEligibilityCheckRequired(requestDTO)).isFalse();
     }
 
     @Test
-    public void givenRepOrderWithNoAssessment_whenIsEligibilityCheckRequiredIsInvoked_thenExceptionIsThrown() {
+    void givenRepOrderWithNoAssessment_whenIsEligibilityCheckRequiredIsInvoked_thenExceptionIsThrown() {
         requestDTO.setFinancialAssessmentId(8234);
         assertThatThrownBy(
                 () -> crownCourtEligibilityService.isEligibilityCheckRequired(requestDTO)
@@ -93,41 +95,41 @@ public class CrownCourtEligibilityServiceTest {
     }
 
     @Test
-    public void givenEWCommittedReassessmentInitFailedAndDateCreatedOnMagsOutcomeDateSet_whenIsEligibilityCheckRequiredIsInvoked_thenTrueIsReturned() {
+    void givenEWCommittedReassessmentInitFailedAndDateCreatedOnMagsOutcomeDateSet_whenIsEligibilityCheckRequiredIsInvoked_thenTrueIsReturned() {
         financialAssessment.setInitResult(InitAssessmentResult.FAIL.getResult());
         financialAssessment.setDateCreated(TestModelDataBuilder.TEST_MAGS_OUTCOME_DATE);
         assertThat(crownCourtEligibilityService.isEligibilityCheckRequired(requestDTO)).isTrue();
     }
 
     @Test
-    public void givenEWCommittedReassessmentInitFailedAndDateCreatedAfterMagsOutcomeDateSet_whenIsEligibilityCheckRequiredIsInvoked_thenTrueIsReturned() {
+    void givenEWCommittedReassessmentInitFailedAndDateCreatedAfterMagsOutcomeDateSet_whenIsEligibilityCheckRequiredIsInvoked_thenTrueIsReturned() {
         financialAssessment.setInitResult(InitAssessmentResult.FAIL.getResult());
         financialAssessment.setDateCreated(TestModelDataBuilder.TEST_MAGS_OUTCOME_DATE.plusDays(1));
         assertThat(crownCourtEligibilityService.isEligibilityCheckRequired(requestDTO)).isTrue();
     }
 
     @Test
-    public void givenEWCommittedReassessmentInitFailedAndDateCreatedBeforeMagsOutcomeDateSet_whenIsEligibilityCheckRequiredIsInvoked_thenTrueIsReturned() {
+    void givenEWCommittedReassessmentInitFailedAndDateCreatedBeforeMagsOutcomeDateSet_whenIsEligibilityCheckRequiredIsInvoked_thenTrueIsReturned() {
         financialAssessment.setInitResult(InitAssessmentResult.FAIL.getResult());
         financialAssessment.setDateCreated(TestModelDataBuilder.TEST_MAGS_OUTCOME_DATE.minusDays(1));
         assertThat(crownCourtEligibilityService.isEligibilityCheckRequired(requestDTO)).isTrue();
     }
 
     @Test
-    public void givenNoPreviousAssessmentResults_whenIsEligibilityCheckRequiredIsInvoked_thenTrueIsReturned() {
+    void givenNoPreviousAssessmentResults_whenIsEligibilityCheckRequiredIsInvoked_thenTrueIsReturned() {
         assertThat(crownCourtEligibilityService.isEligibilityCheckRequired(requestDTO)).isTrue();
     }
 
     @Test
-        public void givenPreviousAssessmentIsPassedInitMeans_whenIsEligibilityCheckRequiredIsInvoked_thenReturnFalse() {
-            FinancialAssessmentDTO previous =
-                    FinancialAssessmentDTO.builder().initResult(InitAssessmentResult.PASS.getResult()).build();
-            repOrderDTO.getFinancialAssessments().add(previous);
-            assertThat(crownCourtEligibilityService.isEligibilityCheckRequired(requestDTO)).isFalse();
+    void givenPreviousAssessmentIsPassedInitMeans_whenIsEligibilityCheckRequiredIsInvoked_thenReturnFalse() {
+        FinancialAssessmentDTO previous =
+                FinancialAssessmentDTO.builder().initResult(InitAssessmentResult.PASS.getResult()).build();
+        repOrderDTO.getFinancialAssessments().add(previous);
+        assertThat(crownCourtEligibilityService.isEligibilityCheckRequired(requestDTO)).isFalse();
     }
 
     @Test
-    public void givenPreviousAssessmentIsFailedInitMeans_whenIsEligibilityCheckRequiredIsInvoked_thenReturnTrue() {
+    void givenPreviousAssessmentIsFailedInitMeans_whenIsEligibilityCheckRequiredIsInvoked_thenReturnTrue() {
         FinancialAssessmentDTO previous =
                 FinancialAssessmentDTO.builder().initResult(InitAssessmentResult.FAIL.getResult()).build();
         repOrderDTO.getFinancialAssessments().add(previous);
@@ -135,7 +137,7 @@ public class CrownCourtEligibilityServiceTest {
     }
 
     @Test
-    public void givenPreviousAssessmentIsFailedFullMeans_whenIsEligibilityCheckRequiredIsInvoked_thenReturnFalse() {
+    void givenPreviousAssessmentIsFailedFullMeans_whenIsEligibilityCheckRequiredIsInvoked_thenReturnFalse() {
         FinancialAssessmentDTO previous =
                 FinancialAssessmentDTO.builder().fullResult(FullAssessmentResult.FAIL.getResult()).build();
         repOrderDTO.getFinancialAssessments().add(previous);
@@ -143,7 +145,7 @@ public class CrownCourtEligibilityServiceTest {
     }
 
     @Test
-    public void givenPreviousAssessmentIsPassedFullMeans_whenIsEligibilityCheckRequiredIsInvoked_thenReturnFalse() {
+    void givenPreviousAssessmentIsPassedFullMeans_whenIsEligibilityCheckRequiredIsInvoked_thenReturnFalse() {
         FinancialAssessmentDTO previous =
                 FinancialAssessmentDTO.builder().fullResult(FullAssessmentResult.PASS.getResult()).build();
         repOrderDTO.getFinancialAssessments().add(previous);
@@ -151,7 +153,7 @@ public class CrownCourtEligibilityServiceTest {
     }
 
     @Test
-    public void givenPreviousAssessmentIsFailedPassport_whenIsEligibilityCheckRequiredIsInvoked_thenReturnTrue() {
+    void givenPreviousAssessmentIsFailedPassport_whenIsEligibilityCheckRequiredIsInvoked_thenReturnTrue() {
         PassportAssessmentDTO previous =
                 PassportAssessmentDTO.builder().result(PassportAssessmentResult.FAIL.getResult()).build();
         repOrderDTO.getPassportAssessments().add(previous);
@@ -159,7 +161,7 @@ public class CrownCourtEligibilityServiceTest {
     }
 
     @Test
-    public void givenPreviousAssessmentIsPassedPassport_whenIsEligibilityCheckRequiredIsInvoked_thenReturnFalse() {
+    void givenPreviousAssessmentIsPassedPassport_whenIsEligibilityCheckRequiredIsInvoked_thenReturnFalse() {
         PassportAssessmentDTO previous =
                 PassportAssessmentDTO.builder().result(PassportAssessmentResult.PASS.getResult()).build();
         repOrderDTO.getPassportAssessments().add(previous);
@@ -167,7 +169,7 @@ public class CrownCourtEligibilityServiceTest {
     }
 
     @Test
-    public void givenIncorrectCaseType_whenIsEligibilityCheckRequiredIsInvoked_thenReturnFalse() {
+    void givenIncorrectCaseType_whenIsEligibilityCheckRequiredIsInvoked_thenReturnFalse() {
         requestDTO.setCaseType(CaseType.APPEAL_CC);
         softly.assertThat(crownCourtEligibilityService.isEligibilityCheckRequired(requestDTO)).isFalse();
 

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/FullAssessmentAvailabilityServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/FullAssessmentAvailabilityServiceTest.java
@@ -1,9 +1,9 @@
 package uk.gov.justice.laa.crime.meansassessment.service;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.CaseType;
@@ -13,22 +13,22 @@ import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.NewWorkReason;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@RunWith(MockitoJUnitRunner.class)
-public class FullAssessmentAvailabilityServiceTest {
+@ExtendWith(MockitoExtension.class)
+class FullAssessmentAvailabilityServiceTest {
 
     private FullAssessmentAvailabilityService fullAssessmentAvailabilityService;
 
     private MeansAssessmentRequestDTO meansAssessmentRequest;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         fullAssessmentAvailabilityService = new FullAssessmentAvailabilityService();
         meansAssessmentRequest = TestModelDataBuilder.getMeansAssessmentRequestDTO(true);
         meansAssessmentRequest.setFullAssessmentDate(null);
     }
 
     @Test
-    public void givenMeansAssessmentRequestAndResponse_WhenResultIsFull_ThenFullAssessmentAvailableIsTrue() {
+    void givenMeansAssessmentRequestAndResponse_WhenResultIsFull_ThenFullAssessmentAvailableIsTrue() {
         assertThat(fullAssessmentAvailabilityService.isFullAssessmentAvailable(
                 meansAssessmentRequest.getCaseType(),
                 meansAssessmentRequest.getMagCourtOutcome(),
@@ -37,7 +37,7 @@ public class FullAssessmentAvailabilityServiceTest {
     }
 
     @Test
-    public void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsIndictable_ThenFullAssessmentAvailableIsTrue() {
+    void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsIndictable_ThenFullAssessmentAvailableIsTrue() {
         assertThat(fullAssessmentAvailabilityService.isFullAssessmentAvailable(
                 CaseType.INDICTABLE,
                 meansAssessmentRequest.getMagCourtOutcome(),
@@ -46,7 +46,7 @@ public class FullAssessmentAvailabilityServiceTest {
     }
 
     @Test
-    public void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsCCAlready_ThenFullAssessmentAvailableIsTrue() {
+    void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsCCAlready_ThenFullAssessmentAvailableIsTrue() {
         assertThat(fullAssessmentAvailabilityService.isFullAssessmentAvailable(
                 CaseType.CC_ALREADY,
                 meansAssessmentRequest.getMagCourtOutcome(),
@@ -55,7 +55,7 @@ public class FullAssessmentAvailabilityServiceTest {
     }
 
     @Test
-    public void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsAppealCC_ThenFullAssessmentAvailableIsTrue() {
+    void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsAppealCC_ThenFullAssessmentAvailableIsTrue() {
         assertThat(fullAssessmentAvailabilityService.isFullAssessmentAvailable(
                 CaseType.APPEAL_CC,
                 meansAssessmentRequest.getMagCourtOutcome(),
@@ -64,7 +64,7 @@ public class FullAssessmentAvailabilityServiceTest {
     }
 
     @Test
-    public void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsCommittal_ThenFullAssessmentAvailableIsFalse() {
+    void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsCommittal_ThenFullAssessmentAvailableIsFalse() {
         assertThat(fullAssessmentAvailabilityService.isFullAssessmentAvailable(
                 CaseType.COMMITAL,
                 meansAssessmentRequest.getMagCourtOutcome(),
@@ -73,7 +73,7 @@ public class FullAssessmentAvailabilityServiceTest {
     }
 
     @Test
-    public void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsSummaryOnly_ThenFullAssessmentAvailableIsFalse() {
+    void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsSummaryOnly_ThenFullAssessmentAvailableIsFalse() {
         assertThat(fullAssessmentAvailabilityService.isFullAssessmentAvailable(
                 CaseType.SUMMARY_ONLY,
                 meansAssessmentRequest.getMagCourtOutcome(),
@@ -82,7 +82,7 @@ public class FullAssessmentAvailabilityServiceTest {
     }
 
     @Test
-    public void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsEitherWayWithMagOutcomeNull_ThenFullAssessmentAvailableIsTrue() {
+    void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsEitherWayWithMagOutcomeNull_ThenFullAssessmentAvailableIsTrue() {
         assertThat(fullAssessmentAvailabilityService.isFullAssessmentAvailable(
                 CaseType.EITHER_WAY,
                 MagCourtOutcome.COMMITTED,
@@ -91,7 +91,7 @@ public class FullAssessmentAvailabilityServiceTest {
     }
 
     @Test
-    public void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsEitherWayWithMagOutcomeCommittedForTrial_ThenFullAssessmentAvailableIsTrue() {
+    void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsEitherWayWithMagOutcomeCommittedForTrial_ThenFullAssessmentAvailableIsTrue() {
         assertThat(fullAssessmentAvailabilityService.isFullAssessmentAvailable(
                 CaseType.EITHER_WAY,
                 MagCourtOutcome.COMMITTED_FOR_TRIAL,
@@ -100,7 +100,7 @@ public class FullAssessmentAvailabilityServiceTest {
     }
 
     @Test
-    public void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsEitherWayWithMagOutcomeAppealCC_ThenFullAssessmentAvailableIsFalse() {
+    void givenMeansAssessmentRequestAndResponse_WhenResultIsFailAndCaseTypeIsEitherWayWithMagOutcomeAppealCC_ThenFullAssessmentAvailableIsFalse() {
         assertThat(fullAssessmentAvailabilityService.isFullAssessmentAvailable(
                 CaseType.EITHER_WAY,
                 MagCourtOutcome.APPEAL_TO_CC,
@@ -109,7 +109,7 @@ public class FullAssessmentAvailabilityServiceTest {
     }
 
     @Test
-    public void givenMeansAssessmentRequestAndResponse_WhenResultIsHardshipAndNewWorkReasonNull_ThenFullAssessmentAvailableIsFalse() {
+    void givenMeansAssessmentRequestAndResponse_WhenResultIsHardshipAndNewWorkReasonNull_ThenFullAssessmentAvailableIsFalse() {
         assertThat(fullAssessmentAvailabilityService.isFullAssessmentAvailable(
                 meansAssessmentRequest.getCaseType(),
                 meansAssessmentRequest.getMagCourtOutcome(),
@@ -118,7 +118,7 @@ public class FullAssessmentAvailabilityServiceTest {
     }
 
     @Test
-    public void givenMeansAssessmentRequestAndResponse_WhenResultIsHardshipAndNewWorkReasonIsHR_ThenFullAssessmentAvailableIsTrue() {
+    void givenMeansAssessmentRequestAndResponse_WhenResultIsHardshipAndNewWorkReasonIsHR_ThenFullAssessmentAvailableIsTrue() {
         assertThat(fullAssessmentAvailabilityService.isFullAssessmentAvailable(
                 meansAssessmentRequest.getCaseType(),
                 meansAssessmentRequest.getMagCourtOutcome(),
@@ -127,7 +127,7 @@ public class FullAssessmentAvailabilityServiceTest {
     }
 
     @Test
-    public void givenMeansAssessmentRequestAndResponse_WhenResultIsHardshipAndNewWorkReasonIsPBI_ThenFullAssessmentAvailableIsFalse() {
+    void givenMeansAssessmentRequestAndResponse_WhenResultIsHardshipAndNewWorkReasonIsPBI_ThenFullAssessmentAvailableIsFalse() {
         assertThat(fullAssessmentAvailabilityService.isFullAssessmentAvailable(
                 meansAssessmentRequest.getCaseType(),
                 meansAssessmentRequest.getMagCourtOutcome(),
@@ -136,7 +136,7 @@ public class FullAssessmentAvailabilityServiceTest {
     }
 
     @Test
-    public void givenMeansAssessmentRequestAndResponse_WhenResultIsNull_ThenFullAssessmentAvailableIsFalse() {
+    void givenMeansAssessmentRequestAndResponse_WhenResultIsNull_ThenFullAssessmentAvailableIsFalse() {
         assertThat(fullAssessmentAvailabilityService.isFullAssessmentAvailable(
                 meansAssessmentRequest.getCaseType(),
                 meansAssessmentRequest.getMagCourtOutcome(),

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/FullMeansAssessmentServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/FullMeansAssessmentServiceTest.java
@@ -1,12 +1,12 @@
 package uk.gov.justice.laa.crime.meansassessment.service;
 
 import org.assertj.core.api.SoftAssertions;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentDTO;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
@@ -22,8 +22,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class FullMeansAssessmentServiceTest {
+@ExtendWith(MockitoExtension.class)
+class FullMeansAssessmentServiceTest {
 
     private final BigDecimal EXPECTED_ADJUSTED_LIVING_ALLOWANCE = BigDecimal.valueOf(6000)
             .setScale(2, RoundingMode.HALF_UP);
@@ -39,8 +39,8 @@ public class FullMeansAssessmentServiceTest {
     @Mock
     private AssessmentCriteriaChildWeightingService childWeightingService;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         when(childWeightingService.getTotalChildWeighting(
                 anyList(), any(AssessmentCriteriaEntity.class))
         ).thenReturn(TestModelDataBuilder.TEST_TOTAL_CHILD_WEIGHTING);
@@ -50,7 +50,7 @@ public class FullMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenCompletedAssessment_whenDoFullAssessmentIsInvoked_thenMeansAssessmentDTOIsReturned() {
+    void givenCompletedAssessment_whenDoFullAssessmentIsInvoked_thenMeansAssessmentDTOIsReturned() {
         MeansAssessmentDTO result =
                 fullMeansAssessmentService.execute(TestModelDataBuilder.TEST_TOTAL_EXPENDITURE, meansAssessment, assessmentCriteria);
 
@@ -67,7 +67,7 @@ public class FullMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenIncompleteAssessment_whenDoFullAssessmentIsInvoked_thenMeansAssessmentDTOIsReturned() {
+    void givenIncompleteAssessment_whenDoFullAssessmentIsInvoked_thenMeansAssessmentDTOIsReturned() {
 
         meansAssessment.setAssessmentStatus(CurrentStatus.IN_PROGRESS);
         MeansAssessmentDTO result =
@@ -88,7 +88,7 @@ public class FullMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenCorrectParameters_whenGetDisposableIncomeIsInvoked_thenCalculationIsCorrect() {
+    void givenCorrectParameters_whenGetDisposableIncomeIsInvoked_thenCalculationIsCorrect() {
         BigDecimal result = fullMeansAssessmentService.getDisposableIncome(
                 TestModelDataBuilder.TEST_AGGREGATED_INCOME,
                 TestModelDataBuilder.TEST_TOTAL_EXPENDITURE,
@@ -98,7 +98,7 @@ public class FullMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenAggregatedAndDisposableIncome_whenGetAnnualAggregatedExpenditureIsInvoked_thenResultIsCorrect() {
+    void givenAggregatedAndDisposableIncome_whenGetAnnualAggregatedExpenditureIsInvoked_thenResultIsCorrect() {
         BigDecimal aggregatedExpenditure = fullMeansAssessmentService.getAnnualAggregatedExpenditure(
                 TestModelDataBuilder.TEST_AGGREGATED_INCOME, TestModelDataBuilder.TEST_DISPOSABLE_INCOME
         );
@@ -106,7 +106,7 @@ public class FullMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenCorrectParameters_whenGetAdjustedLivingAllowanceIsInvoked_thenCalculationIsCorrect() {
+    void givenCorrectParameters_whenGetAdjustedLivingAllowanceIsInvoked_thenCalculationIsCorrect() {
         when(childWeightingService.getTotalChildWeighting(anyList(), any(AssessmentCriteriaEntity.class)))
                 .thenReturn(TestModelDataBuilder.TEST_TOTAL_CHILD_WEIGHTING);
         BigDecimal result = fullMeansAssessmentService.getAdjustedLivingAllowance(meansAssessment, assessmentCriteria);
@@ -114,7 +114,7 @@ public class FullMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenDisposableIncomeAboveThreshold_whenGetResultIsInvoked_thenResultIsFail() {
+    void givenDisposableIncomeAboveThreshold_whenGetResultIsInvoked_thenResultIsFail() {
         BigDecimal disposableIncome =
                 assessmentCriteria.getFullThreshold().add(BigDecimal.valueOf(0.01));
         FullAssessmentResult result =
@@ -123,7 +123,7 @@ public class FullMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenDisposableIncomeBelowThreshold_whenGetResultIsInvoked_thenResultIsPass() {
+    void givenDisposableIncomeBelowThreshold_whenGetResultIsInvoked_thenResultIsPass() {
         BigDecimal disposableIncome =
                 assessmentCriteria.getFullThreshold().subtract(BigDecimal.valueOf(0.01));
         FullAssessmentResult result =
@@ -132,7 +132,7 @@ public class FullMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenEligibilityCheckRequiredAndIncomeBelowThreshold_whenGetResultIsInvoked_thenResultIsPass() {
+    void givenEligibilityCheckRequiredAndIncomeBelowThreshold_whenGetResultIsInvoked_thenResultIsPass() {
         BigDecimal disposableIncome =
                 assessmentCriteria.getEligibilityThreshold().subtract(BigDecimal.valueOf(0.01));
         assertThat(fullMeansAssessmentService.getResult(disposableIncome, meansAssessment, assessmentCriteria))
@@ -140,7 +140,7 @@ public class FullMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenEligibilityCheckRequiredAndEqualsThreshold_whenGetResultIsInvoked_thenResultIsPass() {
+    void givenEligibilityCheckRequiredAndEqualsThreshold_whenGetResultIsInvoked_thenResultIsPass() {
         BigDecimal disposableIncome =
                 assessmentCriteria.getEligibilityThreshold();
         meansAssessment.setEligibilityCheckRequired(true);
@@ -149,7 +149,7 @@ public class FullMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenEligibilityCheckRequiredAndIncomeAboveThreshold_whenGetResultIsInvoked_thenResultIsPass() {
+    void givenEligibilityCheckRequiredAndIncomeAboveThreshold_whenGetResultIsInvoked_thenResultIsPass() {
         BigDecimal disposableIncome =
                 assessmentCriteria.getEligibilityThreshold().add(BigDecimal.valueOf(0.01));
         meansAssessment.setEligibilityCheckRequired(true);

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/IncomeEvidenceServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/IncomeEvidenceServiceTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
- class IncomeEvidenceServiceTest {
+class IncomeEvidenceServiceTest {
 
     @InjectMocks
     private IncomeEvidenceService incomeEvidenceService;
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
     private IncomeEvidenceRepository incomeEvidenceRepository;
 
     @Test
-     void testIncomeEvidenceService_whenGetIncomeEvidenceByIdInvoked_shouldSuccess() {
+    void testIncomeEvidenceService_whenGetIncomeEvidenceByIdInvoked_shouldSuccess() {
         incomeEvidenceService.getIncomeEvidenceById("NINO");
         verify(incomeEvidenceRepository, times(1)).findById(any());
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/IncomeEvidenceServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/IncomeEvidenceServiceTest.java
@@ -1,18 +1,18 @@
 package uk.gov.justice.laa.crime.meansassessment.service;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.repository.IncomeEvidenceRepository;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
-public class IncomeEvidenceServiceTest {
+@ExtendWith(MockitoExtension.class)
+ class IncomeEvidenceServiceTest {
 
     @InjectMocks
     private IncomeEvidenceService incomeEvidenceService;
@@ -21,7 +21,7 @@ public class IncomeEvidenceServiceTest {
     private IncomeEvidenceRepository incomeEvidenceRepository;
 
     @Test
-    public void testIncomeEvidenceService_whenGetIncomeEvidenceByIdInvoked_shouldSuccess() {
+     void testIncomeEvidenceService_whenGetIncomeEvidenceByIdInvoked_shouldSuccess() {
         incomeEvidenceService.getIncomeEvidenceById("NINO");
         verify(incomeEvidenceRepository, times(1)).findById(any());
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/InitMeansAssessmentServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/InitMeansAssessmentServiceTest.java
@@ -1,13 +1,13 @@
 package uk.gov.justice.laa.crime.meansassessment.service;
 
 import org.assertj.core.api.SoftAssertions;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentDTO;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
@@ -24,8 +24,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class InitMeansAssessmentServiceTest {
+@ExtendWith(MockitoExtension.class)
+ class InitMeansAssessmentServiceTest {
 
     private final AssessmentCriteriaEntity assessmentCriteria =
             TestModelDataBuilder.getAssessmentCriteriaEntityWithDetails();
@@ -43,15 +43,15 @@ public class InitMeansAssessmentServiceTest {
     @Mock
     private AssessmentCriteriaChildWeightingService childWeightingService;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+     void setUp() {
         when(childWeightingService.getTotalChildWeighting(
                 anyList(), any(AssessmentCriteriaEntity.class))
         ).thenReturn(TestModelDataBuilder.TEST_TOTAL_CHILD_WEIGHTING);
     }
 
     @Test
-    public void givenCompletedAssessment_whenDoInitAssessmentIsInvoked_thenMeansAssessmentDTOIsReturned() {
+     void givenCompletedAssessment_whenDoInitAssessmentIsInvoked_thenMeansAssessmentDTOIsReturned() {
         MeansAssessmentDTO result =
                 initMeansAssessmentService.execute(TestModelDataBuilder.TEST_AGGREGATED_INCOME, meansAssessment, assessmentCriteria);
 
@@ -65,7 +65,7 @@ public class InitMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenIncompleteAssessment_whenDoInitAssessmentIsInvoked_thenMeansAssessmentDTOIsReturned() {
+     void givenIncompleteAssessment_whenDoInitAssessmentIsInvoked_thenMeansAssessmentDTOIsReturned() {
         meansAssessment.setAssessmentStatus(CurrentStatus.IN_PROGRESS);
         MeansAssessmentDTO result =
                 initMeansAssessmentService.execute(TestModelDataBuilder.TEST_AGGREGATED_INCOME, meansAssessment, assessmentCriteria);
@@ -80,7 +80,7 @@ public class InitMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenIncomeBelowLowerThreshold_whenGetAssessmentResultIsInvoked_thenResultIsPass() {
+     void givenIncomeBelowLowerThreshold_whenGetAssessmentResultIsInvoked_thenResultIsPass() {
         BigDecimal adjustedIncome = lowerThreshold.subtract(BigDecimal.valueOf(0.01));
         InitAssessmentResult result =
                 initMeansAssessmentService.getResult(adjustedIncome, assessmentCriteria, NewWorkReason.FMA);
@@ -88,7 +88,7 @@ public class InitMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenIncomeBetweenThresholds_whenGetAssessmentResultIsInvoked_thenResultIsFull() {
+     void givenIncomeBetweenThresholds_whenGetAssessmentResultIsInvoked_thenResultIsFull() {
         BigDecimal adjustedIncome = lowerThreshold.add(BigDecimal.valueOf(0.01));
         InitAssessmentResult result =
                 initMeansAssessmentService.getResult(adjustedIncome, assessmentCriteria, NewWorkReason.FMA);
@@ -96,7 +96,7 @@ public class InitMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenIncomeAboveUpperThreshold_whenGetAssessmentResultIsInvoked_thenResultIsFail() {
+     void givenIncomeAboveUpperThreshold_whenGetAssessmentResultIsInvoked_thenResultIsFail() {
         BigDecimal adjustedIncome = upperThreshold.add(BigDecimal.valueOf(0.01));
         InitAssessmentResult result =
                 initMeansAssessmentService.getResult(adjustedIncome, assessmentCriteria, NewWorkReason.FMA);
@@ -104,7 +104,7 @@ public class InitMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenIncomeAboveUpperThresholdAndHardshipApplication_whenGetAssessmentResultIsInvoked_thenResultIsHardship() {
+     void givenIncomeAboveUpperThresholdAndHardshipApplication_whenGetAssessmentResultIsInvoked_thenResultIsHardship() {
         BigDecimal adjustedIncome = upperThreshold.add(BigDecimal.valueOf(0.01));
         InitAssessmentResult result =
                 initMeansAssessmentService.getResult(adjustedIncome, assessmentCriteria, NewWorkReason.HR);
@@ -112,7 +112,7 @@ public class InitMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenPositiveAnnualTotal_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
+     void givenPositiveAnnualTotal_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
         BigDecimal annualTotal = BigDecimal.valueOf(11000.00);
         BigDecimal totalChildWeighting = BigDecimal.valueOf(0.50);
         BigDecimal applicantWeightingFactor = TestModelDataBuilder.TEST_APPLICANT_WEIGHTING_FACTOR;
@@ -123,7 +123,7 @@ public class InitMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenPositiveAnnualTotalRequiringRounding_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
+     void givenPositiveAnnualTotalRequiringRounding_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
         BigDecimal annualTotal = BigDecimal.valueOf(36613.02);
         BigDecimal totalChildWeighting = BigDecimal.valueOf(0);
         BigDecimal applicantWeightingFactor = BigDecimal.valueOf(1.0);
@@ -134,7 +134,7 @@ public class InitMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenPositiveAnnualTotalChildWeightingRoundingError_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
+     void givenPositiveAnnualTotalChildWeightingRoundingError_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
         BigDecimal annualTotal = BigDecimal.valueOf(37506.00);
         BigDecimal totalChildWeighting = BigDecimal.valueOf(0.68);
         BigDecimal applicantWeightingFactor = BigDecimal.valueOf(1.00);
@@ -145,7 +145,7 @@ public class InitMeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenZeroAnnualTotal_whenGetAdjustedIncomeIsInvoked_thenReturnsZero() {
+     void givenZeroAnnualTotal_whenGetAdjustedIncomeIsInvoked_thenReturnsZero() {
         BigDecimal annualTotal = BigDecimal.ZERO;
         when(childWeightingService.getTotalChildWeighting(
                 anyList(), any(AssessmentCriteriaEntity.class))

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/InitMeansAssessmentServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/InitMeansAssessmentServiceTest.java
@@ -25,7 +25,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
- class InitMeansAssessmentServiceTest {
+class InitMeansAssessmentServiceTest {
 
     private final AssessmentCriteriaEntity assessmentCriteria =
             TestModelDataBuilder.getAssessmentCriteriaEntityWithDetails();
@@ -44,14 +44,14 @@ import static org.mockito.Mockito.when;
     private AssessmentCriteriaChildWeightingService childWeightingService;
 
     @BeforeEach
-     void setUp() {
+    void setUp() {
         when(childWeightingService.getTotalChildWeighting(
                 anyList(), any(AssessmentCriteriaEntity.class))
         ).thenReturn(TestModelDataBuilder.TEST_TOTAL_CHILD_WEIGHTING);
     }
 
     @Test
-     void givenCompletedAssessment_whenDoInitAssessmentIsInvoked_thenMeansAssessmentDTOIsReturned() {
+    void givenCompletedAssessment_whenDoInitAssessmentIsInvoked_thenMeansAssessmentDTOIsReturned() {
         MeansAssessmentDTO result =
                 initMeansAssessmentService.execute(TestModelDataBuilder.TEST_AGGREGATED_INCOME, meansAssessment, assessmentCriteria);
 
@@ -65,7 +65,7 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
-     void givenIncompleteAssessment_whenDoInitAssessmentIsInvoked_thenMeansAssessmentDTOIsReturned() {
+    void givenIncompleteAssessment_whenDoInitAssessmentIsInvoked_thenMeansAssessmentDTOIsReturned() {
         meansAssessment.setAssessmentStatus(CurrentStatus.IN_PROGRESS);
         MeansAssessmentDTO result =
                 initMeansAssessmentService.execute(TestModelDataBuilder.TEST_AGGREGATED_INCOME, meansAssessment, assessmentCriteria);
@@ -80,7 +80,7 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
-     void givenIncomeBelowLowerThreshold_whenGetAssessmentResultIsInvoked_thenResultIsPass() {
+    void givenIncomeBelowLowerThreshold_whenGetAssessmentResultIsInvoked_thenResultIsPass() {
         BigDecimal adjustedIncome = lowerThreshold.subtract(BigDecimal.valueOf(0.01));
         InitAssessmentResult result =
                 initMeansAssessmentService.getResult(adjustedIncome, assessmentCriteria, NewWorkReason.FMA);
@@ -88,7 +88,7 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
-     void givenIncomeBetweenThresholds_whenGetAssessmentResultIsInvoked_thenResultIsFull() {
+    void givenIncomeBetweenThresholds_whenGetAssessmentResultIsInvoked_thenResultIsFull() {
         BigDecimal adjustedIncome = lowerThreshold.add(BigDecimal.valueOf(0.01));
         InitAssessmentResult result =
                 initMeansAssessmentService.getResult(adjustedIncome, assessmentCriteria, NewWorkReason.FMA);
@@ -96,7 +96,7 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
-     void givenIncomeAboveUpperThreshold_whenGetAssessmentResultIsInvoked_thenResultIsFail() {
+    void givenIncomeAboveUpperThreshold_whenGetAssessmentResultIsInvoked_thenResultIsFail() {
         BigDecimal adjustedIncome = upperThreshold.add(BigDecimal.valueOf(0.01));
         InitAssessmentResult result =
                 initMeansAssessmentService.getResult(adjustedIncome, assessmentCriteria, NewWorkReason.FMA);
@@ -104,7 +104,7 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
-     void givenIncomeAboveUpperThresholdAndHardshipApplication_whenGetAssessmentResultIsInvoked_thenResultIsHardship() {
+    void givenIncomeAboveUpperThresholdAndHardshipApplication_whenGetAssessmentResultIsInvoked_thenResultIsHardship() {
         BigDecimal adjustedIncome = upperThreshold.add(BigDecimal.valueOf(0.01));
         InitAssessmentResult result =
                 initMeansAssessmentService.getResult(adjustedIncome, assessmentCriteria, NewWorkReason.HR);
@@ -112,7 +112,7 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
-     void givenPositiveAnnualTotal_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
+    void givenPositiveAnnualTotal_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
         BigDecimal annualTotal = BigDecimal.valueOf(11000.00);
         BigDecimal totalChildWeighting = BigDecimal.valueOf(0.50);
         BigDecimal applicantWeightingFactor = TestModelDataBuilder.TEST_APPLICANT_WEIGHTING_FACTOR;
@@ -123,7 +123,7 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
-     void givenPositiveAnnualTotalRequiringRounding_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
+    void givenPositiveAnnualTotalRequiringRounding_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
         BigDecimal annualTotal = BigDecimal.valueOf(36613.02);
         BigDecimal totalChildWeighting = BigDecimal.valueOf(0);
         BigDecimal applicantWeightingFactor = BigDecimal.valueOf(1.0);
@@ -134,7 +134,7 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
-     void givenPositiveAnnualTotalChildWeightingRoundingError_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
+    void givenPositiveAnnualTotalChildWeightingRoundingError_whenGetAdjustedIncomeIsInvoked_thenAdjustedIncomeIsCalculated() {
         BigDecimal annualTotal = BigDecimal.valueOf(37506.00);
         BigDecimal totalChildWeighting = BigDecimal.valueOf(0.68);
         BigDecimal applicantWeightingFactor = BigDecimal.valueOf(1.00);
@@ -145,7 +145,7 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
-     void givenZeroAnnualTotal_whenGetAdjustedIncomeIsInvoked_thenReturnsZero() {
+    void givenZeroAnnualTotal_whenGetAdjustedIncomeIsInvoked_thenReturnsZero() {
         BigDecimal annualTotal = BigDecimal.ZERO;
         when(childWeightingService.getTotalChildWeighting(
                 anyList(), any(AssessmentCriteriaEntity.class))

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/MaatCourtDataServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/MaatCourtDataServiceTest.java
@@ -1,11 +1,11 @@
 package uk.gov.justice.laa.crime.meansassessment.service;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.commons.client.RestAPIClient;
 import uk.gov.justice.laa.crime.meansassessment.config.MaatApiConfiguration;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
@@ -20,8 +20,8 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class MaatCourtDataServiceTest {
+@ExtendWith(MockitoExtension.class)
+class MaatCourtDataServiceTest {
 
     private static final String LAA_TRANSACTION_ID = "laaTransactionId";
 
@@ -35,7 +35,7 @@ public class MaatCourtDataServiceTest {
     private MaatApiConfiguration maatApiConfiguration = MockMaatApiConfiguration.getConfiguration(1000);
 
     @Test
-    public void givenCreateRequest_whenPersistMeansAssessmentIsInvoked_thenPostRequestIsSentToCourtDataApi() {
+    void givenCreateRequest_whenPersistMeansAssessmentIsInvoked_thenPostRequestIsSentToCourtDataApi() {
         MaatApiAssessmentResponse expected = new MaatApiAssessmentResponse().withId(1234);
 
         when(maatAPIClient.post(any(MaatApiAssessmentRequest.class), any(), anyString(), anyMap()))
@@ -47,7 +47,7 @@ public class MaatCourtDataServiceTest {
     }
 
     @Test
-    public void givenUpdateRequest_whenPersistMeansAssessmentIsInvoked_thenPutRequestIsSentToCourtDataApi() {
+    void givenUpdateRequest_whenPersistMeansAssessmentIsInvoked_thenPutRequestIsSentToCourtDataApi() {
         MaatApiAssessmentResponse expected = new MaatApiAssessmentResponse().withId(5678);
         when(maatAPIClient.put(any(MaatApiAssessmentRequest.class), any(), anyString(), anyMap()))
                 .thenReturn(expected);
@@ -58,7 +58,7 @@ public class MaatCourtDataServiceTest {
     }
 
     @Test
-    public void givenRepId_whenGetPassportAssessmentFromRepIdIsInvoked_thenResponseIsReturned() {
+    void givenRepId_whenGetPassportAssessmentFromRepIdIsInvoked_thenResponseIsReturned() {
         PassportAssessmentDTO expected = new PassportAssessmentDTO();
         when(maatAPIClient.get(any(), anyString(), anyMap(), any()))
                 .thenReturn(expected);
@@ -70,7 +70,7 @@ public class MaatCourtDataServiceTest {
     }
 
     @Test
-    public void givenRepId_whenGetHardshipReviewFromRepIdIsInvoked_thenResponseIsReturned() {
+    void givenRepId_whenGetHardshipReviewFromRepIdIsInvoked_thenResponseIsReturned() {
         HardshipReviewDTO expected = new HardshipReviewDTO();
         when(maatAPIClient.get(any(), anyString(), anyMap(), any()))
                 .thenReturn(expected);
@@ -82,7 +82,7 @@ public class MaatCourtDataServiceTest {
     }
 
     @Test
-    public void givenRepId_whenGetIojAppealFromRepIdIsInvoked_thenResponseIsReturned() {
+    void givenRepId_whenGetIojAppealFromRepIdIsInvoked_thenResponseIsReturned() {
         IOJAppealDTO expected = new IOJAppealDTO();
         when(maatAPIClient.get(any(), anyString(), anyMap(), any()))
                 .thenReturn(expected);
@@ -94,7 +94,7 @@ public class MaatCourtDataServiceTest {
     }
 
     @Test
-    public void givenRepId_whenGetFinancialAssessmentIsInvoked_thenResponseIsReturned() {
+    void givenRepId_whenGetFinancialAssessmentIsInvoked_thenResponseIsReturned() {
         FinancialAssessmentDTO expected = new FinancialAssessmentDTO();
         when(maatAPIClient.get(any(), anyString(), anyMap(), any()))
                 .thenReturn(expected);
@@ -106,7 +106,7 @@ public class MaatCourtDataServiceTest {
     }
 
     @Test
-    public void givenRepId_whenGetRepOrderIsInvoked_thenResponseIsReturned() {
+    void givenRepId_whenGetRepOrderIsInvoked_thenResponseIsReturned() {
         RepOrderDTO expected = new RepOrderDTO();
         when(maatAPIClient.get(any(), anyString(), anyMap(), any()))
                 .thenReturn(expected);
@@ -118,7 +118,7 @@ public class MaatCourtDataServiceTest {
     }
 
     @Test
-    public void givenDateCompletionRequest_whenUpdateCompletionDateIsInvoked_thenResponseIsReturned() {
+    void givenDateCompletionRequest_whenUpdateCompletionDateIsInvoked_thenResponseIsReturned() {
         maatCourtDataService.updateCompletionDate(DateCompletionRequestDTO.builder().build(), LAA_TRANSACTION_ID);
         verify(maatAPIClient).post(
                 any(DateCompletionRequestDTO.class),

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/MeansAssessmentServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/MeansAssessmentServiceTest.java
@@ -1,15 +1,15 @@
 package uk.gov.justice.laa.crime.meansassessment.service;
 
 import org.assertj.core.api.SoftAssertions;
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.meansassessment.builder.MaatCourtDataAssessmentBuilder;
 import uk.gov.justice.laa.crime.meansassessment.builder.MeansAssessmentResponseBuilder;
 import uk.gov.justice.laa.crime.meansassessment.builder.MeansAssessmentSectionSummaryBuilder;
@@ -42,8 +42,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
-public class MeansAssessmentServiceTest {
+@ExtendWith(MockitoExtension.class)
+class MeansAssessmentServiceTest {
 
     private final AssessmentCriteriaEntity assessmentCriteria =
             TestModelDataBuilder.getAssessmentCriteriaEntityWithDetails();
@@ -83,14 +83,14 @@ public class MeansAssessmentServiceTest {
     @Mock
     private CrownCourtEligibilityService crownCourtEligibilityService;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         assessmentCriteria.setId(TestModelDataBuilder.TEST_CRITERIA_ID);
         featuresConfiguration.setDateCompletionEnabled(false);
     }
 
     @AfterEach
-    public void resetMeansAssessment() {
+    void resetMeansAssessment() {
         meansAssessment.setAssessmentStatus(TestModelDataBuilder.TEST_ASSESSMENT_STATUS);
         meansAssessment.setSectionSummaries(TestModelDataBuilder.getApiAssessmentSummaries(true));
     }
@@ -130,12 +130,12 @@ public class MeansAssessmentServiceTest {
         ).thenReturn(maatApiAssessmentResponse);
 
         when(meansAssessmentResponseBuilder.build(any(MaatApiAssessmentResponse.class),
-                        any(AssessmentCriteriaEntity.class),
-                        any(MeansAssessmentDTO.class))).thenReturn(new ApiMeansAssessmentResponse());
+                any(AssessmentCriteriaEntity.class),
+                any(MeansAssessmentDTO.class))).thenReturn(new ApiMeansAssessmentResponse());
     }
 
     @Test
-    public void givenInitAssessmentType_whenDoAssessmentIsInvoked_thenCreateAssessmentIsPerformed() {
+    void givenInitAssessmentType_whenDoAssessmentIsInvoked_thenCreateAssessmentIsPerformed() {
         setupDoAssessmentStubbing(AssessmentType.INIT);
         meansAssessmentService.doAssessment(meansAssessment, AssessmentRequestType.CREATE);
 
@@ -152,7 +152,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenFullAssessmentType_whenDoAssessmentIsInvoked_thenFullAssessmentIsPerformed() {
+    void givenFullAssessmentType_whenDoAssessmentIsInvoked_thenFullAssessmentIsPerformed() {
         setupDoAssessmentStubbing(AssessmentType.FULL);
 
         meansAssessment.setAssessmentType(AssessmentType.FULL);
@@ -168,7 +168,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenUnexpectedFailure_whenDoAssessmentIsInvoked_thenAssessmentProcessingExceptionIsThrown() {
+    void givenUnexpectedFailure_whenDoAssessmentIsInvoked_thenAssessmentProcessingExceptionIsThrown() {
 
         doThrow(new RuntimeException()).when(assessmentCriteriaService).getAssessmentCriteria(
                 any(LocalDateTime.class), anyBoolean(), anyBoolean()
@@ -182,7 +182,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenMaatApiAssessmentResponse_whenUpdateDetailIdsIsInvoked_thenDetailIdsAreUpdated() {
+    void givenMaatApiAssessmentResponse_whenUpdateDetailIdsIsInvoked_thenDetailIdsAreUpdated() {
         MeansAssessmentDTO meansAssessmentDTO = TestModelDataBuilder.getMeansAssessmentDTO();
         meansAssessmentService.updateDetailIds(
                 meansAssessmentDTO, TestModelDataBuilder.getMaatApiInitAssessmentResponse()
@@ -192,14 +192,14 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenEmptyAssessmentDetails_whenGetAssessmentSectionSummaryInvoked_thenReturnEmptyAssessmentSectionSummaryList() {
+    void givenEmptyAssessmentDetails_whenGetAssessmentSectionSummaryInvoked_thenReturnEmptyAssessmentSectionSummaryList() {
         List<ApiAssessmentSectionSummary> assessmentSectionSummaryList =
                 meansAssessmentService.getAssessmentSectionSummary(TestModelDataBuilder.getFinancialAssessmentDTO());
         assertThat(true).isEqualTo(assessmentSectionSummaryList.isEmpty());
     }
 
     @Test
-    public void givenEmptyAssessmentCriteriaDetail_whenGetAssessmentSectionSummaryInvoked_thenReturnEmptyAssessmentSectionSummaryList() {
+    void givenEmptyAssessmentCriteriaDetail_whenGetAssessmentSectionSummaryInvoked_thenReturnEmptyAssessmentSectionSummaryList() {
         List<ApiAssessmentSectionSummary> assessmentSectionSummaryList =
                 meansAssessmentService.getAssessmentSectionSummary(
                         TestModelDataBuilder.getFinancialAssessmentDTOWithDetails()
@@ -208,7 +208,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenAssessmentDetails_whenGetAssessmentSectionSummaryInvoked_thenReturnAssessmentSectionSummaryList() {
+    void givenAssessmentDetails_whenGetAssessmentSectionSummaryInvoked_thenReturnAssessmentSectionSummaryList() {
 
         doReturn(Optional.of(TestModelDataBuilder.getAssessmentCriteriaDetailEntity(TestModelDataBuilder.TEST_ASSESSMENT_SECTION_INITA)))
                 .when(assessmentCriteriaDetailService).getAssessmentCriteriaDetailById(any());
@@ -220,14 +220,14 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void testGetAssessmentDTOInvoked_whenNonAssessmentCriteriaDetail_thenReturnEmpty() {
+    void testGetAssessmentDTOInvoked_whenNonAssessmentCriteriaDetail_thenReturnEmpty() {
         doReturn(Optional.empty()).when(assessmentCriteriaDetailService).getAssessmentCriteriaDetailById(any());
         List<AssessmentDTO> assessmentDTOS = meansAssessmentService.getAssessmentDTO(TestModelDataBuilder.getAssessmentDetails());
         assertThat(0).isEqualTo(assessmentDTOS.size());
     }
 
     @Test
-    public void testGetAssessmentDTOInvoked_whenAssessmentCriteriaDetailFound_thenReturnAssessment() {
+    void testGetAssessmentDTOInvoked_whenAssessmentCriteriaDetailFound_thenReturnAssessment() {
         doReturn(Optional.of(TestModelDataBuilder.getAssessmentCriteriaDetailEntity(TestModelDataBuilder.TEST_ASSESSMENT_SECTION_INITA)))
                 .when(assessmentCriteriaDetailService).getAssessmentCriteriaDetailById(any());
         when(meansAssessmentSectionSummaryBuilder.buildAssessmentDTO(any(), any())).thenReturn(TestModelDataBuilder
@@ -238,7 +238,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void testSortAssessmentDetailInvoked_whenAssessmentFound_thenReturnSortedBySectionAndSequence() {
+    void testSortAssessmentDetailInvoked_whenAssessmentFound_thenReturnSortedBySectionAndSequence() {
 
         List<AssessmentDTO> assessmentDTOList = new ArrayList<>();
         assessmentDTOList.add(TestModelDataBuilder.getAssessmentDTO(TestModelDataBuilder.TEST_ASSESSMENT_SECTION_INITA,
@@ -266,7 +266,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenInvalidAssessmentId_whenGetOldAssessmentInvoked_thenReturnEmpty() {
+    void givenInvalidAssessmentId_whenGetOldAssessmentInvoked_thenReturnEmpty() {
 
         when(maatCourtDataService.getFinancialAssessment(any(), any())).thenReturn(null);
         ApiGetMeansAssessmentResponse apiMeansAssessmentResponse =
@@ -279,7 +279,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenAssessmentId_whenGetOldAssessmentInvoked_thenReturnAssessment() {
+    void givenAssessmentId_whenGetOldAssessmentInvoked_thenReturnAssessment() {
         doReturn(Optional.of(TestModelDataBuilder.getAssessmentCriteriaDetailEntity(TestModelDataBuilder.TEST_ASSESSMENT_SECTION_INITA)))
                 .when(assessmentCriteriaDetailService).getAssessmentCriteriaDetailById(any());
         when(meansAssessmentSectionSummaryBuilder.buildAssessmentDTO(any(), any())).thenReturn(TestModelDataBuilder
@@ -292,7 +292,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenEmptyChildWeightings_whenMapChildWeightingsInvoked_thenResponseIsPopulatedWithEmptyChildWeightingsList() {
+    void givenEmptyChildWeightings_whenMapChildWeightingsInvoked_thenResponseIsPopulatedWithEmptyChildWeightingsList() {
         ApiInitialMeansAssessment apiInitialMeansAssessment = new ApiInitialMeansAssessment();
         meansAssessmentService.mapChildWeightings(apiInitialMeansAssessment, TestModelDataBuilder
                 .getFinancialAssessmentDTOWithDetails());
@@ -300,7 +300,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenChildWeightings_whenMapChildWeightingsInvoked_thenResponseIsPopulatedWithChildWeightingsList() {
+    void givenChildWeightings_whenMapChildWeightingsInvoked_thenResponseIsPopulatedWithChildWeightingsList() {
         ApiInitialMeansAssessment apiInitialMeansAssessment = new ApiInitialMeansAssessment();
         doReturn(Optional.of(TestModelDataBuilder.getAssessmentCriteriaChildWeightingEntity()))
                 .when(assessmentCriteriaService).getAssessmentCriteriaChildWeightingsById(any());
@@ -310,7 +310,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenAssessmentCriteriaChildWeightingsEmpty_whenMapChildWeightingsInvoked_thenResponseIsPopulatedWithNoChildWeightingsList() {
+    void givenAssessmentCriteriaChildWeightingsEmpty_whenMapChildWeightingsInvoked_thenResponseIsPopulatedWithNoChildWeightingsList() {
         ApiInitialMeansAssessment apiInitialMeansAssessment = new ApiInitialMeansAssessment();
         meansAssessmentService.mapChildWeightings(apiInitialMeansAssessment, TestModelDataBuilder
                 .getFinancialAssessmentDTOWithChildWeightings());
@@ -318,7 +318,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenIncomeEvidenceList_whenSortFinAssIncomeEvidenceSummaryIsInvoked_thenReturnSortedList() {
+    void givenIncomeEvidenceList_whenSortFinAssIncomeEvidenceSummaryIsInvoked_thenReturnSortedList() {
 
         List<FinAssIncomeEvidenceDTO> finAssIncomeEvidenceDTOList = new ArrayList<>();
         finAssIncomeEvidenceDTOList.add(TestModelDataBuilder.getFinAssIncomeEvidenceDTO("N", "OTHER BUSINESS"));
@@ -343,7 +343,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenEmptyFinAssIncomeEvidence_whenMapIncomeEvidenceInvoked_thenResponseIsPopulatedWithEmptyIncomeEvidenceList() {
+    void givenEmptyFinAssIncomeEvidence_whenMapIncomeEvidenceInvoked_thenResponseIsPopulatedWithEmptyIncomeEvidenceList() {
         ApiGetMeansAssessmentResponse apiGetMeansAssessmentResponse = new ApiGetMeansAssessmentResponse()
                 .withIncomeEvidenceSummary(new ApiIncomeEvidenceSummary());
         meansAssessmentService.mapIncomeEvidence(apiGetMeansAssessmentResponse, TestModelDataBuilder
@@ -352,7 +352,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenIncomeEvidences_whenMapIncomeEvidenceInvoked_thenResponseIsPopulatedWithIncomeEvidenceList() {
+    void givenIncomeEvidences_whenMapIncomeEvidenceInvoked_thenResponseIsPopulatedWithIncomeEvidenceList() {
         ApiGetMeansAssessmentResponse apiGetMeansAssessmentResponse = new ApiGetMeansAssessmentResponse()
                 .withIncomeEvidenceSummary(new ApiIncomeEvidenceSummary());
         doReturn(Optional.of(TestModelDataBuilder.getIncomeEvidenceEntity()))
@@ -363,7 +363,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenInvalidEvidence_whenGetEvidenceTypeInvoked_thenEvidenceDescriptionIsNull() {
+    void givenInvalidEvidence_whenGetEvidenceTypeInvoked_thenEvidenceDescriptionIsNull() {
         String evidence = "NONE";
         ApiEvidenceType apiEvidenceType = meansAssessmentService.getEvidenceType(evidence);
         assertThat(evidence).isEqualTo(apiEvidenceType.getCode());
@@ -389,7 +389,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenInitAssessment_whenBuildMeansAssessmentResponseIsInvoked_thenBuildFullAssessmentResponse() {
+    void givenInitAssessment_whenBuildMeansAssessmentResponseIsInvoked_thenBuildFullAssessmentResponse() {
         ApiGetMeansAssessmentResponse response = new ApiGetMeansAssessmentResponse();
         FinancialAssessmentDTO financialAssessmentDTO = TestModelDataBuilder.getFinancialAssessmentDTO();
         meansAssessmentService.buildMeansAssessmentResponse(response, financialAssessmentDTO);
@@ -410,7 +410,7 @@ public class MeansAssessmentServiceTest {
     }
 
     @Test
-    public void givenFullAssessment_whenBuildMeansAssessmentResponseIsInvoked_thenBuildFullAssessmentResponse() {
+    void givenFullAssessment_whenBuildMeansAssessmentResponseIsInvoked_thenBuildFullAssessmentResponse() {
         FinancialAssessmentDTO financialAssessmentDTO = TestModelDataBuilder.getFinancialAssessmentDTO();
         financialAssessmentDTO.setAssessmentType(AssessmentType.FULL.getType());
         financialAssessmentDTO.setFullAscrId(TestModelDataBuilder.TEST_CRITERIA_ID);

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/stateless/StatelessAssessmentServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/stateless/StatelessAssessmentServiceTest.java
@@ -33,7 +33,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
- class StatelessAssessmentServiceTest {
+class StatelessAssessmentServiceTest {
 
     private static final AssessmentCriteriaEntity mockAssessmentCriteria =
             TestModelDataBuilder.getAssessmentCriteriaEntity();
@@ -60,7 +60,7 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
-     void givenInitRequestType_whenExecuteIsInvoked_thenInitAssessmentIsPerformed() {
+    void givenInitRequestType_whenExecuteIsInvoked_thenInitAssessmentIsPerformed() {
 
         setupStubs();
 
@@ -88,7 +88,7 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
-     void givenBothRequestType_whenExecuteIsInvoked_thenFullAssessmentIsPerformed() {
+    void givenBothRequestType_whenExecuteIsInvoked_thenFullAssessmentIsPerformed() {
 
         setupStubs();
 
@@ -122,7 +122,7 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
-     void givenBothRequestTypeAndInitAssessmentFails_whenExecuteIsInvoked_thenOnlyInitAssessmentIsPerformed() {
+    void givenBothRequestTypeAndInitAssessmentFails_whenExecuteIsInvoked_thenOnlyInitAssessmentIsPerformed() {
         setupStubs();
 
         when(initMeansAssessmentService.execute(

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/stateless/StatelessAssessmentServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/stateless/StatelessAssessmentServiceTest.java
@@ -1,12 +1,12 @@
 package uk.gov.justice.laa.crime.meansassessment.service.stateless;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentDTO;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
@@ -32,29 +32,23 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
-@RunWith(SpringRunner.class)
-public class StatelessAssessmentServiceTest {
-
-    @InjectMocks
-    private StatelessAssessmentService statelessAssessmentService;
-
-    @Mock
-    private InitMeansAssessmentService initMeansAssessmentService;
-
-    @Mock
-    private FullMeansAssessmentService fullMeansAssessmentService;
-
-    @Mock
-    private MeansAssessmentServiceFactory meansAssessmentServiceFactory;
-
-    @Mock
-    private AssessmentCriteriaService assessmentCriteriaService;
-
-    @Mock
-    private FullAssessmentAvailabilityService fullAssessmentAvailabilityService;
+@ExtendWith(SpringExtension.class)
+ class StatelessAssessmentServiceTest {
 
     private static final AssessmentCriteriaEntity mockAssessmentCriteria =
             TestModelDataBuilder.getAssessmentCriteriaEntity();
+    @InjectMocks
+    private StatelessAssessmentService statelessAssessmentService;
+    @Mock
+    private InitMeansAssessmentService initMeansAssessmentService;
+    @Mock
+    private FullMeansAssessmentService fullMeansAssessmentService;
+    @Mock
+    private MeansAssessmentServiceFactory meansAssessmentServiceFactory;
+    @Mock
+    private AssessmentCriteriaService assessmentCriteriaService;
+    @Mock
+    private FullAssessmentAvailabilityService fullAssessmentAvailabilityService;
 
     private void setupStubs() {
         when(meansAssessmentServiceFactory.getService(AssessmentType.INIT))
@@ -66,7 +60,7 @@ public class StatelessAssessmentServiceTest {
     }
 
     @Test
-    public void givenInitRequestType_whenExecuteIsInvoked_thenInitAssessmentIsPerformed() {
+     void givenInitRequestType_whenExecuteIsInvoked_thenInitAssessmentIsPerformed() {
 
         setupStubs();
 
@@ -94,7 +88,7 @@ public class StatelessAssessmentServiceTest {
     }
 
     @Test
-    public void givenBothRequestType_whenExecuteIsInvoked_thenFullAssessmentIsPerformed() {
+     void givenBothRequestType_whenExecuteIsInvoked_thenFullAssessmentIsPerformed() {
 
         setupStubs();
 
@@ -128,7 +122,7 @@ public class StatelessAssessmentServiceTest {
     }
 
     @Test
-    public void givenBothRequestTypeAndInitAssessmentFails_whenExecuteIsInvoked_thenOnlyInitAssessmentIsPerformed() {
+     void givenBothRequestTypeAndInitAssessmentFails_whenExecuteIsInvoked_thenOnlyInitAssessmentIsPerformed() {
         setupStubs();
 
         when(initMeansAssessmentService.execute(

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/stateless/StatelessDataAdaptorTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/stateless/StatelessDataAdaptorTest.java
@@ -1,7 +1,7 @@
 package uk.gov.justice.laa.crime.meansassessment.service.stateless;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.model.common.ApiAssessmentChildWeighting;
 import uk.gov.justice.laa.crime.meansassessment.model.common.ApiAssessmentDetail;
@@ -23,14 +23,14 @@ import java.util.Set;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class StatelessDataAdaptorTest {
+ class StatelessDataAdaptorTest {
 
 
-    private Set<AssessmentCriteriaChildWeightingEntity> childWeightingEntities;
     private final AssessmentCriteriaEntity assessmentCriteria = TestModelDataBuilder.getAssessmentCriteriaEntity();
+    private Set<AssessmentCriteriaChildWeightingEntity> childWeightingEntities;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+     void setup() {
         assessmentCriteria.setAssessmentCriteriaDetails(
                 Set.of(
                         AssessmentCriteriaDetailEntity.builder()
@@ -92,7 +92,7 @@ public class StatelessDataAdaptorTest {
     }
 
     @Test
-    public void givenValidApplicantIncomes_whenMapIncomesToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
+     void givenValidApplicantIncomes_whenMapIncomesToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
         List<Income> incomes = List.of(
                 buildIncome(IncomeType.EMPLOYMENT_INCOME, BigDecimal.valueOf(1500), Frequency.MONTHLY),
                 buildIncome(IncomeType.SELF_EMPLOYMENT_INCOME, BigDecimal.valueOf(500), Frequency.ANNUALLY)
@@ -126,7 +126,7 @@ public class StatelessDataAdaptorTest {
     }
 
     @Test
-    public void givenValidApplicantAndPartnerIncomes_whenMapIncomesToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
+     void givenValidApplicantAndPartnerIncomes_whenMapIncomesToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
         List<Income> incomes = List.of(
                 buildIncome(IncomeType.EMPLOYMENT_INCOME,
                         BigDecimal.valueOf(1500),
@@ -174,7 +174,7 @@ public class StatelessDataAdaptorTest {
     }
 
     @Test
-    public void givenValidApplicantOutgoings_whenMapOutgoingsToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
+     void givenValidApplicantOutgoings_whenMapOutgoingsToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
         List<Outgoing> outgoings = List.of(
                 buildOutgoing(OutgoingType.COUNCIL_TAX, BigDecimal.valueOf(500), Frequency.ANNUALLY),
                 buildOutgoing(OutgoingType.NATIONAL_INSURANCE, BigDecimal.valueOf(1500), Frequency.MONTHLY)
@@ -208,7 +208,7 @@ public class StatelessDataAdaptorTest {
     }
 
     @Test
-    public void givenValidApplicantAndPartnerOutgoings_whenMapOutgoingsToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
+     void givenValidApplicantAndPartnerOutgoings_whenMapOutgoingsToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
         List<Outgoing> outgoings = List.of(
                 buildOutgoing(OutgoingType.COUNCIL_TAX,
                         BigDecimal.valueOf(500),
@@ -257,7 +257,7 @@ public class StatelessDataAdaptorTest {
     }
 
     @Test
-    public void givenValidWeightsAndNoGroupings_whenMapChildGroupingsIsInvoked_thenMappingIsPerformed() {
+     void givenValidWeightsAndNoGroupings_whenMapChildGroupingsIsInvoked_thenMappingIsPerformed() {
 
         List<ApiAssessmentChildWeighting> expected = List.of(
                 new ApiAssessmentChildWeighting()
@@ -276,7 +276,7 @@ public class StatelessDataAdaptorTest {
     }
 
     @Test
-    public void givenValidWeightsAndGroupings_whenMapChildGroupingsIsInvoked_thenMappingIsPerformed() {
+     void givenValidWeightsAndGroupings_whenMapChildGroupingsIsInvoked_thenMappingIsPerformed() {
 
         Map<AgeRange, Integer> childGroupings = Map.of(
                 AgeRange.ZERO_TO_ONE, 1,

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/stateless/StatelessDataAdaptorTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/stateless/StatelessDataAdaptorTest.java
@@ -23,14 +23,14 @@ import java.util.Set;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
- class StatelessDataAdaptorTest {
+class StatelessDataAdaptorTest {
 
 
     private final AssessmentCriteriaEntity assessmentCriteria = TestModelDataBuilder.getAssessmentCriteriaEntity();
     private Set<AssessmentCriteriaChildWeightingEntity> childWeightingEntities;
 
     @BeforeEach
-     void setup() {
+    void setup() {
         assessmentCriteria.setAssessmentCriteriaDetails(
                 Set.of(
                         AssessmentCriteriaDetailEntity.builder()
@@ -92,7 +92,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenValidApplicantIncomes_whenMapIncomesToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
+    void givenValidApplicantIncomes_whenMapIncomesToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
         List<Income> incomes = List.of(
                 buildIncome(IncomeType.EMPLOYMENT_INCOME, BigDecimal.valueOf(1500), Frequency.MONTHLY),
                 buildIncome(IncomeType.SELF_EMPLOYMENT_INCOME, BigDecimal.valueOf(500), Frequency.ANNUALLY)
@@ -126,7 +126,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenValidApplicantAndPartnerIncomes_whenMapIncomesToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
+    void givenValidApplicantAndPartnerIncomes_whenMapIncomesToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
         List<Income> incomes = List.of(
                 buildIncome(IncomeType.EMPLOYMENT_INCOME,
                         BigDecimal.valueOf(1500),
@@ -174,7 +174,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenValidApplicantOutgoings_whenMapOutgoingsToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
+    void givenValidApplicantOutgoings_whenMapOutgoingsToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
         List<Outgoing> outgoings = List.of(
                 buildOutgoing(OutgoingType.COUNCIL_TAX, BigDecimal.valueOf(500), Frequency.ANNUALLY),
                 buildOutgoing(OutgoingType.NATIONAL_INSURANCE, BigDecimal.valueOf(1500), Frequency.MONTHLY)
@@ -208,7 +208,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenValidApplicantAndPartnerOutgoings_whenMapOutgoingsToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
+    void givenValidApplicantAndPartnerOutgoings_whenMapOutgoingsToSectionSummariesIsInvoked_thenSectionSummariesAreReturned() {
         List<Outgoing> outgoings = List.of(
                 buildOutgoing(OutgoingType.COUNCIL_TAX,
                         BigDecimal.valueOf(500),
@@ -257,7 +257,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenValidWeightsAndNoGroupings_whenMapChildGroupingsIsInvoked_thenMappingIsPerformed() {
+    void givenValidWeightsAndNoGroupings_whenMapChildGroupingsIsInvoked_thenMappingIsPerformed() {
 
         List<ApiAssessmentChildWeighting> expected = List.of(
                 new ApiAssessmentChildWeighting()
@@ -276,7 +276,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     }
 
     @Test
-     void givenValidWeightsAndGroupings_whenMapChildGroupingsIsInvoked_thenMappingIsPerformed() {
+    void givenValidWeightsAndGroupings_whenMapChildGroupingsIsInvoked_thenMappingIsPerformed() {
 
         Map<AgeRange, Integer> childGroupings = Map.of(
                 AgeRange.ZERO_TO_ONE, 1,

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/CurrentStatusTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/CurrentStatusTest.java
@@ -1,24 +1,25 @@
 package uk.gov.justice.laa.crime.meansassessment.staticdata.enums;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class CurrentStatusTest {
+class CurrentStatusTest {
 
     @Test
-    public void valueOfCurrentStatusFromString_success() {
+    void valueOfCurrentStatusFromString_success() {
         assertEquals(CurrentStatus.IN_PROGRESS, CurrentStatus.getFrom("IN PROGRESS"));
     }
 
     @Test
-    public void valueOfCurrentStatusFromString_nullParameter_ReturnsNull() {
-        Assert.assertThrows(IllegalArgumentException.class, () -> CurrentStatus.getFrom(null));
+    void valueOfCurrentStatusFromString_nullParameter_ReturnsNull() {
+        assertThrows(IllegalArgumentException.class, () -> CurrentStatus.getFrom(null));
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void valueOfCurrentStatusFromString_valueNotFound_throwsException() {
-        CurrentStatus.getFrom("THROWS_EXCEPTION");
+    @Test
+    void valueOfCurrentStatusFromString_valueNotFound_throwsException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CurrentStatus.getFrom("THROWS_EXCEPTION"));
     }
 }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/FrequencyTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/FrequencyTest.java
@@ -1,24 +1,24 @@
 package uk.gov.justice.laa.crime.meansassessment.staticdata.enums;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class FrequencyTest {
+class FrequencyTest {
 
     @Test
-    public void valueOfFrequencyFromString_success() {
+    void valueOfFrequencyFromString_success() {
         assertEquals(Frequency.TWO_WEEKLY, Frequency.getFrom("2WEEKLY"));
     }
 
     @Test
-    public void valueOfFrequencyFromString_nullParamenter_ReturnsNull() {
+    void valueOfFrequencyFromString_nullParamenter_ReturnsNull() {
         assertNull(Frequency.getFrom(null));
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void valueOfFrequencyFromString_valueNotFound_throwsException() {
-        Frequency.getFrom("THROWS_EXCEPTION");
+    @Test
+    void valueOfFrequencyFromString_valueNotFound_throwsException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> Frequency.getFrom("THROWS_EXCEPTION"));
     }
 }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/NewWorkReasonTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/NewWorkReasonTest.java
@@ -1,24 +1,24 @@
 package uk.gov.justice.laa.crime.meansassessment.staticdata.enums;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-public class NewWorkReasonTest {
+class NewWorkReasonTest {
 
     @Test
-    public void givenValidResultString_whenGetFromIsInvoked_thenCorrectEnumIsReturned() {
+    void givenValidResultString_whenGetFromIsInvoked_thenCorrectEnumIsReturned() {
         assertThat(NewWorkReason.getFrom("FMA")).isEqualTo(NewWorkReason.FMA);
     }
 
     @Test
-    public void givenBlankString_whenGetFromIsInvoked_thenNullIsReturned() {
+    void givenBlankString_whenGetFromIsInvoked_thenNullIsReturned() {
         assertThat(NewWorkReason.getFrom(null)).isNull();
     }
 
     @Test
-    public void givenInvalidResultString_whenGetFromIsInvoked_thenExceptionIsThrown() {
+    void givenInvalidResultString_whenGetFromIsInvoked_thenExceptionIsThrown() {
         assertThatThrownBy(
                 () -> NewWorkReason.getFrom("MOCK_RESULT_STRING")
         ).isInstanceOf(IllegalArgumentException.class);

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/PassportAssessmentResultTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/PassportAssessmentResultTest.java
@@ -1,11 +1,11 @@
 package uk.gov.justice.laa.crime.meansassessment.staticdata.enums;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-public class PassportAssessmentResultTest {
+class PassportAssessmentResultTest {
 
     @Test
     public void givenValidResultString_whenGetFromIsInvoked_thenCorrectEnumIsReturned() {
@@ -14,12 +14,12 @@ public class PassportAssessmentResultTest {
     }
 
     @Test
-    public void givenBlankString_whenGetFromIsInvoked_thenNullIsReturned() {
+    void givenBlankString_whenGetFromIsInvoked_thenNullIsReturned() {
         assertThat(PassportAssessmentResult.getFrom(null)).isNull();
     }
 
     @Test
-    public void givenInvalidResultString_whenGetFromIsInvoked_thenExceptionIsThrown() {
+    void givenInvalidResultString_whenGetFromIsInvoked_thenExceptionIsThrown() {
         assertThatThrownBy(
                 () -> PassportAssessmentResult.getFrom("MOCK_RESULT_STRING")
         ).isInstanceOf(IllegalArgumentException.class);

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/PassportAssessmentResultTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/PassportAssessmentResultTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 class PassportAssessmentResultTest {
 
     @Test
-    public void givenValidResultString_whenGetFromIsInvoked_thenCorrectEnumIsReturned() {
+    void givenValidResultString_whenGetFromIsInvoked_thenCorrectEnumIsReturned() {
         assertThat(PassportAssessmentResult.getFrom("PASS"))
                 .isEqualTo(PassportAssessmentResult.PASS);
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/converter/CaseTypeConverterTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/converter/CaseTypeConverterTest.java
@@ -1,14 +1,15 @@
 package uk.gov.justice.laa.crime.meansassessment.staticdata.enums.converter;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import uk.gov.justice.laa.crime.meansassessment.exception.ValidationException;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.AssessmentRequestType;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.CaseType;
-import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.Frequency;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static uk.gov.justice.laa.crime.meansassessment.validation.validator.MeansAssessmentValidationProcessor.MSG_NEW_WORK_REASON_IS_NOT_VALID;
 
-public class CaseTypeConverterTest {
+class CaseTypeConverterTest {
 
     private static final String VALID_VALUE = "APPEAL CC";
     private static final String INVALID_VALUE = "INVALID_VALUE";
@@ -16,31 +17,33 @@ public class CaseTypeConverterTest {
     private CaseTypeConverter caseTypeConverter = new CaseTypeConverter();
 
     @Test
-    public void givenWhenEnumIsProvidedThenMatchingValueForDBIsReturned() {
+     void givenWhenEnumIsProvidedThenMatchingValueForDBIsReturned() {
         String result = caseTypeConverter.convertToDatabaseColumn(CaseType.APPEAL_CC);
         assertEquals(CaseType.APPEAL_CC.getCaseType(), result);
     }
 
     @Test
-    public void givenWhenValidValueIsInDBThenCorrectEnumIsReturned (){
+     void givenWhenValidValueIsInDBThenCorrectEnumIsReturned() {
         CaseType result = caseTypeConverter.convertToEntityAttribute(VALID_VALUE);
         assertEquals(CaseType.APPEAL_CC, result);
     }
+
     @Test
-    public void givenWhenEnumIsNullThenNullDBValueReturned() {
+     void givenWhenEnumIsNullThenNullDBValueReturned() {
         String result = caseTypeConverter.convertToDatabaseColumn(null);
         assertNull(result);
     }
 
     @Test
-    public void givenWhenDBValueIsNullThenNoEnumIsReturned(){
+     void givenWhenDBValueIsNullThenNoEnumIsReturned() {
         CaseType result = caseTypeConverter.convertToEntityAttribute(null);
         assertNull(result);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void givenWhenInvalidValueIsInDBThenExceptionIsThrown() {
-        caseTypeConverter.convertToEntityAttribute(INVALID_VALUE);
+    @Test
+     void givenWhenInvalidValueIsInDBThenExceptionIsThrown() {
+        assertThrows(IllegalArgumentException.class,
+                () -> caseTypeConverter.convertToEntityAttribute(INVALID_VALUE));
     }
 
 }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/converter/CaseTypeConverterTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/converter/CaseTypeConverterTest.java
@@ -1,13 +1,9 @@
 package uk.gov.justice.laa.crime.meansassessment.staticdata.enums.converter;
 
 import org.junit.jupiter.api.Test;
-import uk.gov.justice.laa.crime.meansassessment.exception.ValidationException;
-import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.AssessmentRequestType;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.CaseType;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static uk.gov.justice.laa.crime.meansassessment.validation.validator.MeansAssessmentValidationProcessor.MSG_NEW_WORK_REASON_IS_NOT_VALID;
 
 class CaseTypeConverterTest {
 
@@ -17,31 +13,31 @@ class CaseTypeConverterTest {
     private CaseTypeConverter caseTypeConverter = new CaseTypeConverter();
 
     @Test
-     void givenWhenEnumIsProvidedThenMatchingValueForDBIsReturned() {
+    void givenWhenEnumIsProvidedThenMatchingValueForDBIsReturned() {
         String result = caseTypeConverter.convertToDatabaseColumn(CaseType.APPEAL_CC);
         assertEquals(CaseType.APPEAL_CC.getCaseType(), result);
     }
 
     @Test
-     void givenWhenValidValueIsInDBThenCorrectEnumIsReturned() {
+    void givenWhenValidValueIsInDBThenCorrectEnumIsReturned() {
         CaseType result = caseTypeConverter.convertToEntityAttribute(VALID_VALUE);
         assertEquals(CaseType.APPEAL_CC, result);
     }
 
     @Test
-     void givenWhenEnumIsNullThenNullDBValueReturned() {
+    void givenWhenEnumIsNullThenNullDBValueReturned() {
         String result = caseTypeConverter.convertToDatabaseColumn(null);
         assertNull(result);
     }
 
     @Test
-     void givenWhenDBValueIsNullThenNoEnumIsReturned() {
+    void givenWhenDBValueIsNullThenNoEnumIsReturned() {
         CaseType result = caseTypeConverter.convertToEntityAttribute(null);
         assertNull(result);
     }
 
     @Test
-     void givenWhenInvalidValueIsInDBThenExceptionIsThrown() {
+    void givenWhenInvalidValueIsInDBThenExceptionIsThrown() {
         assertThrows(IllegalArgumentException.class,
                 () -> caseTypeConverter.convertToEntityAttribute(INVALID_VALUE));
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/converter/CurrentStatusConverterTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/converter/CurrentStatusConverterTest.java
@@ -1,45 +1,47 @@
 package uk.gov.justice.laa.crime.meansassessment.staticdata.enums.converter;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.CurrentStatus;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class CurrentStatusConverterTest {
+class CurrentStatusConverterTest {
 
     private CurrentStatusConverter currentStatusConverter;
 
-    @Before
-    public void init(){
+    @BeforeEach
+    void init() {
         currentStatusConverter = new CurrentStatusConverter();
     }
 
     @Test
-    public void convertToDatabaseColumn_success() {
+    void convertToDatabaseColumn_success() {
         var dbValueReturned = currentStatusConverter.convertToDatabaseColumn(CurrentStatus.IN_PROGRESS);
         assertEquals(CurrentStatus.IN_PROGRESS.getStatus(), dbValueReturned);
     }
+
     @Test
-    public void convertToDatabaseColumn_expectsNull() {
+    void convertToDatabaseColumn_expectsNull() {
         var nullValueReturned = currentStatusConverter.convertToDatabaseColumn(null);
         assertNull(nullValueReturned);
     }
 
     @Test
-    public void convertToCurrentStatus_success(){
+    void convertToCurrentStatus_success() {
         var currentStatusReturned = currentStatusConverter.convertToEntityAttribute("IN PROGRESS");
         assertEquals(CurrentStatus.IN_PROGRESS, currentStatusReturned);
     }
+
     @Test
-    public void convertToCurrentStatus_nullValueReturned(){
+    void convertToCurrentStatus_nullValueReturned() {
         var nullValueReturned = currentStatusConverter.convertToEntityAttribute(null);
         assertNull(nullValueReturned);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void convertToCurrentStatus_valueNotFound_throwsException() {
-        currentStatusConverter.convertToEntityAttribute("THROWS_EXCEPTION");
+    @Test
+    void convertToCurrentStatus_valueNotFound_throwsException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> currentStatusConverter.convertToEntityAttribute("THROWS_EXCEPTION"));
     }
 }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/converter/FrequencyConverterTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/converter/FrequencyConverterTest.java
@@ -1,44 +1,47 @@
 package uk.gov.justice.laa.crime.meansassessment.staticdata.enums.converter;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.CurrentStatus;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.Frequency;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class FrequencyConverterTest {
+class FrequencyConverterTest {
     private FrequencyConverter frequencyConverter;
 
-    @Before
-    public void init(){
+    @BeforeEach
+    void init() {
         frequencyConverter = new FrequencyConverter();
     }
 
     @Test
-    public void convertToDatabaseColumn_success() {
+    void convertToDatabaseColumn_success() {
         var dbValueReturned = frequencyConverter.convertToDatabaseColumn(Frequency.FOUR_WEEKLY);
         assertEquals(Frequency.FOUR_WEEKLY.getCode(), dbValueReturned);
     }
+
     @Test
-    public void convertToDatabaseColumn_expectsNull() {
+    void convertToDatabaseColumn_expectsNull() {
         var nullValueReturned = frequencyConverter.convertToDatabaseColumn(null);
         assertNull(nullValueReturned);
     }
 
     @Test
-    public void convertToFrequency_success(){
+    void convertToFrequency_success() {
         var frequencyReturned = frequencyConverter.convertToEntityAttribute("4WEEKLY");
         assertEquals(Frequency.FOUR_WEEKLY, frequencyReturned);
     }
+
     @Test
-    public void convertToFrequency_nullValueReturned(){
+    void convertToFrequency_nullValueReturned() {
         var nullValueReturned = frequencyConverter.convertToEntityAttribute(null);
         assertNull(nullValueReturned);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void convertToFrequency_valueNotFound_throwsException() {
-        frequencyConverter.convertToEntityAttribute("THROWS_EXCEPTION");
+    @Test
+    void convertToFrequency_valueNotFound_throwsException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> frequencyConverter.convertToEntityAttribute("THROWS_EXCEPTION"));
     }
 }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/converter/FrequencyConverterTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/enums/converter/FrequencyConverterTest.java
@@ -2,7 +2,6 @@ package uk.gov.justice.laa.crime.meansassessment.staticdata.enums.converter;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.CurrentStatus;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.Frequency;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/repository/AssessmentCriteriaRepositoryTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/staticdata/repository/AssessmentCriteriaRepositoryTest.java
@@ -1,28 +1,28 @@
 package uk.gov.justice.laa.crime.meansassessment.staticdata.repository;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.entity.AssessmentCriteriaEntity;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
-@RunWith(SpringRunner.class)
-public class AssessmentCriteriaRepositoryTest {
+@ExtendWith(SpringExtension.class)
+class AssessmentCriteriaRepositoryTest {
 
     private AssessmentCriteriaEntity assessmentCriteriaEntity;
 
     @Autowired
     private AssessmentCriteriaRepository assessmentCriteriaRepository;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         Integer latestCriteriaId = 34;
         assessmentCriteriaEntity = assessmentCriteriaRepository.findById(latestCriteriaId).orElse(null);
         if (assessmentCriteriaEntity == null) {
@@ -31,7 +31,7 @@ public class AssessmentCriteriaRepositoryTest {
     }
 
     @Test
-    public void givenAssessmentCriteriaIsPopulated_WhenValidDateIsProvided_ThenAssessmentCriteriaShouldBeReturned() {
+    void givenAssessmentCriteriaIsPopulated_WhenValidDateIsProvided_ThenAssessmentCriteriaShouldBeReturned() {
         // when valid Date is given
         AssessmentCriteriaEntity result = assessmentCriteriaRepository.findAssessmentCriteriaForDate(TestModelDataBuilder.TEST_DATE_FROM.plusHours(1));
         // then at least one result is returned
@@ -39,7 +39,7 @@ public class AssessmentCriteriaRepositoryTest {
     }
 
     @Test
-    public void givenAssessmentCriteriaIsPopulated_WhenValidDateIsProvidedAndDateToIsNull_ThenAssessmentCriteriaShouldBeReturned() {
+    void givenAssessmentCriteriaIsPopulated_WhenValidDateIsProvidedAndDateToIsNull_ThenAssessmentCriteriaShouldBeReturned() {
         // when valid Date is given
         AssessmentCriteriaEntity result = assessmentCriteriaRepository.findAssessmentCriteriaForDate(TestModelDataBuilder.TEST_DATE_FROM.plusHours(1));
         // then at least one result is returned
@@ -48,7 +48,7 @@ public class AssessmentCriteriaRepositoryTest {
     }
 
     @Test
-    public void givenAssessmentCriteriaIsPopulated_WhenInvalidDateIsProvided_ThenAssessmentCriteriaShouldNotBeReturned() {
+    void givenAssessmentCriteriaIsPopulated_WhenInvalidDateIsProvided_ThenAssessmentCriteriaShouldNotBeReturned() {
         // when invalid Date is given
         AssessmentCriteriaEntity result = assessmentCriteriaRepository.findAssessmentCriteriaForDate(TestModelDataBuilder.TEST_DATE_FROM.minusYears(100));
         // then no results are returned
@@ -56,13 +56,13 @@ public class AssessmentCriteriaRepositoryTest {
     }
 
     @Test
-    public void givenAssessmentCriteriaIsPopulated_WhenOldValidDateIsProvided_ThenAssessmentCriteriaShouldBeReturned() {
+    void givenAssessmentCriteriaIsPopulated_WhenOldValidDateIsProvided_ThenAssessmentCriteriaShouldBeReturned() {
         AssessmentCriteriaEntity result = assessmentCriteriaRepository.findAssessmentCriteriaForDate(assessmentCriteriaEntity.getDateFrom().minusDays(1));
         assertNotEquals(assessmentCriteriaEntity, result);
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         if (assessmentCriteriaEntity != null) {
             assessmentCriteriaRepository.delete(assessmentCriteriaEntity);
             assessmentCriteriaEntity = null;

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/util/RoundingUtilsTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/util/RoundingUtilsTest.java
@@ -1,15 +1,16 @@
 package uk.gov.justice.laa.crime.meansassessment.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class RoundingUtilsTest {
+class RoundingUtilsTest {
+
     @Test
-    public void testRoundingUtilConstructorIsPrivate() throws NoSuchMethodException {
+    void testRoundingUtilConstructorIsPrivate() throws NoSuchMethodException {
         assertThat(RoundingUtils.class.getDeclaredConstructors()).hasSize(1);
         Constructor<RoundingUtils> constructor = RoundingUtils.class.getDeclaredConstructor();
         assertThat(Modifier.isPrivate(constructor.getModifiers())).isTrue();

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/util/SortUtilsTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/util/SortUtilsTest.java
@@ -1,6 +1,6 @@
 package uk.gov.justice.laa.crime.meansassessment.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -8,16 +8,17 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class SortUtilsTest {
+class SortUtilsTest {
+
     @Test
-    public void testSortUtilConstructorIsPrivate() throws NoSuchMethodException {
+    void testSortUtilConstructorIsPrivate() throws NoSuchMethodException {
         assertThat(SortUtils.class.getDeclaredConstructors()).hasSize(1);
         Constructor<SortUtils> constructor = SortUtils.class.getDeclaredConstructor();
         assertThat(Modifier.isPrivate(constructor.getModifiers())).isTrue();
     }
 
     @Test
-    public void testSort_whenNullIsPassed_NullIsReturned() {
+    void testSort_whenNullIsPassed_NullIsReturned() {
         List<String> list = null;
         SortUtils.sortListWithComparing(list, null, null, null);
         assertThat(list).isNull();

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/service/MeansAssessmentValidationServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/service/MeansAssessmentValidationServiceTest.java
@@ -1,12 +1,12 @@
 package uk.gov.justice.laa.crime.meansassessment.validation.service;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.ParameterizedTypeReference;
 import uk.gov.justice.laa.crime.commons.client.RestAPIClient;
 import uk.gov.justice.laa.crime.meansassessment.config.MaatApiConfiguration;
@@ -20,8 +20,8 @@ import uk.gov.justice.laa.crime.meansassessment.util.MockMaatApiConfiguration;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
-public class MeansAssessmentValidationServiceTest {
+@ExtendWith(MockitoExtension.class)
+class MeansAssessmentValidationServiceTest {
 
     private static final AuthorizationResponseDTO TRUE_AUTH_RESPONSE =
             AuthorizationResponseDTO.builder().result(true).build();
@@ -40,111 +40,119 @@ public class MeansAssessmentValidationServiceTest {
     @Spy
     private MaatApiConfiguration maatApiConfiguration = MockMaatApiConfiguration.getConfiguration(1000);
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         requestDTO = TestModelDataBuilder.getMeansAssessmentRequestDTO(true);
     }
 
     @Test
-    public void whenGetUserIdFromRequestIsCalled_thenUserIdIsReturned() {
+    void whenGetUserIdFromRequestIsCalled_thenUserIdIsReturned() {
         assertThat(meansAssessmentValidationService.getUserIdFromRequest(requestDTO))
                 .isEqualTo(TestModelDataBuilder.TEST_USER);
     }
 
     @Test
-    public void givenInvalidNewWorkReason_whenIsNewWorkReasonValidIsInvoked_thenFalseIsReturned() {
+    void givenInvalidNewWorkReason_whenIsNewWorkReasonValidIsInvoked_thenFalseIsReturned() {
         when(maatAPIClient.get(
-                eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {}), anyString(), anyMap(), anyString(), anyString()))
+                eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {
+                }), anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(FALSE_AUTH_RESPONSE);
         assertThat(meansAssessmentValidationService.isNewWorkReasonValid(requestDTO)).isFalse();
     }
 
     @Test
-    public void givenValidNewWorkReason_whenIsNewWorkReasonValidIsInvoked_thenTrueIsReturned() {
-        when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {}), anyString(), anyMap(), anyString(), anyString()))
+    void givenValidNewWorkReason_whenIsNewWorkReasonValidIsInvoked_thenTrueIsReturned() {
+        when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {
+        }), anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(TRUE_AUTH_RESPONSE);
         assertThat(meansAssessmentValidationService.isNewWorkReasonValid(requestDTO)).isTrue();
     }
 
     @Test
-    public void givenNullNewWorkReason_whenIsNewWorkReasonValidIsInvoked_thenFalseIsReturned() {
+    void givenNullNewWorkReason_whenIsNewWorkReasonValidIsInvoked_thenFalseIsReturned() {
         requestDTO.setNewWorkReason(NewWorkReason.getFrom(""));
         assertThat(meansAssessmentValidationService.isNewWorkReasonValid(requestDTO)).isFalse();
     }
 
     @Test
-    public void givenBlankUserId_whenIsRoleActionValidIsInvoked_thenFalseIsReturned() {
+    void givenBlankUserId_whenIsRoleActionValidIsInvoked_thenFalseIsReturned() {
         requestDTO.getUserSession().setUserName("");
         assertThat(meansAssessmentValidationService.isRoleActionValid(requestDTO, "FMA")).isFalse();
     }
 
     @Test
-    public void givenBlankAction_whenIsRoleActionValidIsInvoked_thenFalseIsReturned() {
+    void givenBlankAction_whenIsRoleActionValidIsInvoked_thenFalseIsReturned() {
         assertThat(meansAssessmentValidationService.isRoleActionValid(requestDTO, "")).isFalse();
     }
 
     @Test
-    public void givenInvalidRoleAction_whenIsRoleActionValidIsInvoked_thenFalseIsReturned() {
-        when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {}), anyString(), anyMap(), anyString(), anyString()))
+    void givenInvalidRoleAction_whenIsRoleActionValidIsInvoked_thenFalseIsReturned() {
+        when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {
+        }), anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(FALSE_AUTH_RESPONSE);
         assertThat(meansAssessmentValidationService.isRoleActionValid(requestDTO, "FMA")).isFalse();
     }
 
     @Test
-    public void givenValidRoleAction_whenIsRoleActionValidIsInvoked_thenTrueIsReturned() {
-        when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {}), anyString(), anyMap(), anyString(), anyString()))
+    void givenValidRoleAction_whenIsRoleActionValidIsInvoked_thenTrueIsReturned() {
+        when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {
+        }), anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(TRUE_AUTH_RESPONSE);
         assertThat(meansAssessmentValidationService.isRoleActionValid(requestDTO, "FMA")).isTrue();
     }
 
     @Test
-    public void givenValidReservation_whenIsRepOrderReserved_thenTrueIsReturned() {
-        when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {}), anyString(), anyMap(), anyString(), anyInt(), anyString()))
+    void givenValidReservation_whenIsRepOrderReserved_thenTrueIsReturned() {
+        when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {
+        }), anyString(), anyMap(), anyString(), anyInt(), anyString()))
                 .thenReturn(TRUE_AUTH_RESPONSE);
         assertThat(meansAssessmentValidationService.isRepOrderReserved(requestDTO)).isTrue();
     }
 
     @Test
-    public void givenInvalidReservation_whenIsRepOrderReserved_thenFalseIsReturned() {
-        when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {}), anyString(), anyMap(), anyString(), anyInt(), anyString()))
+    void givenInvalidReservation_whenIsRepOrderReserved_thenFalseIsReturned() {
+        when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {
+        }), anyString(), anyMap(), anyString(), anyInt(), anyString()))
                 .thenReturn(FALSE_AUTH_RESPONSE);
         assertThat(meansAssessmentValidationService.isRepOrderReserved(requestDTO)).isFalse();
     }
 
     @Test
-    public void givenBlankUserIdInRequest_whenIsRepOrderReserved_thenFalseIsReturned() {
+    void givenBlankUserIdInRequest_whenIsRepOrderReserved_thenFalseIsReturned() {
         requestDTO.getUserSession().setUserName("");
         assertThat(meansAssessmentValidationService.isRepOrderReserved(requestDTO)).isFalse();
     }
 
     @Test
-    public void givenBlankSessionIDInRequest_whenIsRepOrderReserved_thenFalseIsReturned() {
+    void givenBlankSessionIDInRequest_whenIsRepOrderReserved_thenFalseIsReturned() {
         requestDTO.getUserSession().setSessionId("");
         assertThat(meansAssessmentValidationService.isRepOrderReserved(requestDTO)).isFalse();
     }
 
     @Test
-    public void givenNullRepIdInRequest_whenIsRepOrderReserved_thenFalseIsReturned() {
+    void givenNullRepIdInRequest_whenIsRepOrderReserved_thenFalseIsReturned() {
         requestDTO.setRepId(null);
         assertThat(meansAssessmentValidationService.isRepOrderReserved(requestDTO)).isFalse();
     }
 
     @Test
-    public void givenAnOutstandingAssessment_whenIsOutstandingAssessmentIsInvoked_thenTrueIsReturned() {
-        when(maatAPIClient.get(eq(new ParameterizedTypeReference<OutstandingAssessmentResultDTO>() {}), anyString(), anyMap(), any()))
+    void givenAnOutstandingAssessment_whenIsOutstandingAssessmentIsInvoked_thenTrueIsReturned() {
+        when(maatAPIClient.get(eq(new ParameterizedTypeReference<OutstandingAssessmentResultDTO>() {
+        }), anyString(), anyMap(), any()))
                 .thenReturn(IS_OUTSTANDING_ASSESSMENT);
         assertThat(meansAssessmentValidationService.isOutstandingAssessment(requestDTO)).isTrue();
     }
 
     @Test
-    public void givenNoOutstandingAssessments_whenIsOutstandingAssessmentIsInvoked_thenFalseIsReturned() {
-        when(maatAPIClient.get(eq(new ParameterizedTypeReference<OutstandingAssessmentResultDTO>() {}), anyString(), anyMap(), any()))
+    void givenNoOutstandingAssessments_whenIsOutstandingAssessmentIsInvoked_thenFalseIsReturned() {
+        when(maatAPIClient.get(eq(new ParameterizedTypeReference<OutstandingAssessmentResultDTO>() {
+        }), anyString(), anyMap(), any()))
                 .thenReturn(NO_OUTSTANDING_ASSESSMENT);
         assertThat(meansAssessmentValidationService.isOutstandingAssessment(requestDTO)).isFalse();
     }
 
     @Test
-    public void givenNoRepId_whenIsOutstandingAssessmentIsInvoked_thenFalseIsReturned() {
+    void givenNoRepId_whenIsOutstandingAssessmentIsInvoked_thenFalseIsReturned() {
         requestDTO.setRepId(null);
         assertThat(meansAssessmentValidationService.isOutstandingAssessment(requestDTO)).isFalse();
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/FullAssessmentValidatorTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/FullAssessmentValidatorTest.java
@@ -1,23 +1,23 @@
 package uk.gov.justice.laa.crime.meansassessment.validation.validator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class FullAssessmentValidatorTest {
+class FullAssessmentValidatorTest {
 
     private final FullAssessmentValidator fullAssessmentValidator = new FullAssessmentValidator();
 
     @Test
-    public void givenFullAssessmentDate_whenValidateIsInvoked_thenValidationPasses() {
+    void givenFullAssessmentDate_whenValidateIsInvoked_thenValidationPasses() {
         assertThat(fullAssessmentValidator.validate(TestModelDataBuilder.getMeansAssessmentRequestDTO(true)))
                 .isEqualTo(Boolean.TRUE);
     }
 
     @Test
-    public void givenNullFullAssessmentDate_whenValidateIsInvoked_thenValidationFails() {
+    void givenNullFullAssessmentDate_whenValidateIsInvoked_thenValidationFails() {
         MeansAssessmentRequestDTO meansAssessment = MeansAssessmentRequestDTO.builder()
                 .fullAssessmentDate(null)
                 .build();

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/InitAssessmentValidatorTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/InitAssessmentValidatorTest.java
@@ -10,10 +10,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 class InitAssessmentValidatorTest {
 
-    private MeansAssessmentRequestDTO meansAssessment;
     private final InitAssessmentValidator initAssessmentValidator = new InitAssessmentValidator();
-
     String REFUSED_REP_ORDER_DECISION = "Refused - Ineligible";
+    private MeansAssessmentRequestDTO meansAssessment;
 
     @BeforeEach
     void setup() {

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/InitAssessmentValidatorTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/InitAssessmentValidatorTest.java
@@ -1,28 +1,28 @@
 package uk.gov.justice.laa.crime.meansassessment.validation.validator;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.ReviewType;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class InitAssessmentValidatorTest {
+class InitAssessmentValidatorTest {
 
     private MeansAssessmentRequestDTO meansAssessment;
     private final InitAssessmentValidator initAssessmentValidator = new InitAssessmentValidator();
 
     String REFUSED_REP_ORDER_DECISION = "Refused - Ineligible";
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         meansAssessment = TestModelDataBuilder.getMeansAssessmentRequestDTO(true);
         meansAssessment.setReviewType(null);
     }
 
     @Test
-    public void givenReviewTypeIsNullAndRepOrderRefused_whenValidateIsInvoked_thenReturnsFalse() {
+    void givenReviewTypeIsNullAndRepOrderRefused_whenValidateIsInvoked_thenReturnsFalse() {
         meansAssessment.getCrownCourtOverview()
                 .getCrownCourtSummary()
                 .setRepOrderDecision(REFUSED_REP_ORDER_DECISION);
@@ -30,20 +30,20 @@ public class InitAssessmentValidatorTest {
     }
 
     @Test
-    public void givenReviewTypeIsNullAndCrownCourtOverviewIsNull_whenValidateIsInvoked_thenReturnsTrue() {
+    void givenReviewTypeIsNullAndCrownCourtOverviewIsNull_whenValidateIsInvoked_thenReturnsTrue() {
         meansAssessment.setCrownCourtOverview(null);
         assertThat(initAssessmentValidator.validate(meansAssessment)).isEqualTo(Boolean.TRUE);
     }
 
     @Test
-    public void givenReviewTypeIsNullAndCrownCourtSummaryIsNull_whenValidateIsInvoked_thenReturnsTrue() {
+    void givenReviewTypeIsNullAndCrownCourtSummaryIsNull_whenValidateIsInvoked_thenReturnsTrue() {
         meansAssessment.getCrownCourtOverview()
                 .setCrownCourtSummary(null);
         assertThat(initAssessmentValidator.validate(meansAssessment)).isEqualTo(Boolean.TRUE);
     }
 
     @Test
-    public void givenReviewTypeIsNullAndRepOrderDecisionIsNull_whenValidateIsInvoked_thenReturnsTrue() {
+    void givenReviewTypeIsNullAndRepOrderDecisionIsNull_whenValidateIsInvoked_thenReturnsTrue() {
         meansAssessment.getCrownCourtOverview()
                 .getCrownCourtSummary()
                 .setRepOrderDecision(null);
@@ -51,7 +51,7 @@ public class InitAssessmentValidatorTest {
     }
 
     @Test
-    public void givenReviewTypeIsNullAndEligibleRepOrderDecision_whenValidateIsInvoked_thenReturnsTrue() {
+    void givenReviewTypeIsNullAndEligibleRepOrderDecision_whenValidateIsInvoked_thenReturnsTrue() {
         meansAssessment.getCrownCourtOverview()
                 .getCrownCourtSummary()
                 .setRepOrderDecision("ELIGIBLE");
@@ -59,7 +59,7 @@ public class InitAssessmentValidatorTest {
     }
 
     @Test
-    public void givenReviewTypeIsNotNull_whenValidateIsInvoked_thenReturnsTrue() {
+    void givenReviewTypeIsNotNull_whenValidateIsInvoked_thenReturnsTrue() {
         meansAssessment.setReviewType(ReviewType.NAFI);
         assertThat(initAssessmentValidator.validate(meansAssessment)).isEqualTo(Boolean.TRUE);
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/MeansAssessmentValidationProcessorTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/MeansAssessmentValidationProcessorTest.java
@@ -1,12 +1,11 @@
 package uk.gov.justice.laa.crime.meansassessment.validation.validator;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
 import uk.gov.justice.laa.crime.meansassessment.exception.ValidationException;
@@ -19,31 +18,27 @@ import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static uk.gov.justice.laa.crime.meansassessment.validation.validator.MeansAssessmentValidationProcessor.*;
 
-@RunWith(MockitoJUnitRunner.class)
-public class MeansAssessmentValidationProcessorTest {
+@ExtendWith(MockitoExtension.class)
+ class MeansAssessmentValidationProcessorTest {
 
+    MeansAssessmentRequestDTO createMeansAssessmentRequest;
+    MeansAssessmentRequestDTO fullAssessment;
     @Mock
     private MeansAssessmentValidationService meansAssessmentValidationService;
-
     @Mock
     private InitAssessmentValidator initAssessmentValidator;
-
     @Mock
     private FullAssessmentValidator fullAssessmentValidator;
-
     @InjectMocks
     private MeansAssessmentValidationProcessor meansAssessmentValidationProcessor;
 
-    MeansAssessmentRequestDTO createMeansAssessmentRequest;
-
-    MeansAssessmentRequestDTO fullAssessment;
-
-    @Before
-    public void setup() {
+    @BeforeEach
+     void setup() {
 
         when(meansAssessmentValidationService.isNewWorkReasonValid(
                 any(MeansAssessmentRequestDTO.class))
@@ -70,7 +65,7 @@ public class MeansAssessmentValidationProcessorTest {
     }
 
     @Test
-    public void givenCreateInitAssessmentRequest_whenAllValidationsPass_thenValidatorDoesNotThrowException() {
+     void givenCreateInitAssessmentRequest_whenAllValidationsPass_thenValidatorDoesNotThrowException() {
         Optional<Void> result =
                 meansAssessmentValidationProcessor.validate(createMeansAssessmentRequest, AssessmentRequestType.CREATE);
 
@@ -86,7 +81,7 @@ public class MeansAssessmentValidationProcessorTest {
     }
 
     @Test
-    public void givenUpdateFullAssessmentRequest_whenAllValidationsPass_thenValidatorDoesNotThrowException() {
+     void givenUpdateFullAssessmentRequest_whenAllValidationsPass_thenValidatorDoesNotThrowException() {
         fullAssessment.setFullAssessmentDate(LocalDateTime.now());
         Optional<Void> result = meansAssessmentValidationProcessor.validate(fullAssessment, AssessmentRequestType.UPDATE);
 
@@ -101,7 +96,7 @@ public class MeansAssessmentValidationProcessorTest {
     }
 
     @Test
-    public void givenInitAssessmentValidationFailure_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+     void givenInitAssessmentValidationFailure_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         when(initAssessmentValidator.validate(
                 any(MeansAssessmentRequestDTO.class))
         ).thenReturn(Boolean.FALSE);
@@ -112,7 +107,7 @@ public class MeansAssessmentValidationProcessorTest {
     }
 
     @Test
-    public void givenFullAssessmentValidationFailure_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+     void givenFullAssessmentValidationFailure_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         when(fullAssessmentValidator.validate(
                 any(MeansAssessmentRequestDTO.class)
         )).thenReturn(Boolean.FALSE);
@@ -123,61 +118,61 @@ public class MeansAssessmentValidationProcessorTest {
     }
 
     @Test
-    public void givenInvalidNewWorkReason_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+     void givenInvalidNewWorkReason_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         when(meansAssessmentValidationService.isNewWorkReasonValid(
                 any(MeansAssessmentRequestDTO.class))
         ).thenReturn(Boolean.FALSE);
 
-        ValidationException validationException = Assert.assertThrows(ValidationException.class,
+        ValidationException validationException = assertThrows(ValidationException.class,
                 () -> meansAssessmentValidationProcessor.validate(createMeansAssessmentRequest, AssessmentRequestType.CREATE));
         assertThat(validationException.getMessage()).isEqualTo(MSG_NEW_WORK_REASON_IS_NOT_VALID);
     }
 
     @Test
-    public void givenNullRepId_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+     void givenNullRepId_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         createMeansAssessmentRequest = TestModelDataBuilder.getMeansAssessmentRequestDTO(false);
-        ValidationException validationException = Assert.assertThrows(ValidationException.class,
+        ValidationException validationException = assertThrows(ValidationException.class,
                 () -> meansAssessmentValidationProcessor.validate(createMeansAssessmentRequest, AssessmentRequestType.UPDATE));
         assertThat(validationException.getMessage()).isEqualTo(MSG_REP_ID_REQUIRED);
     }
 
     @Test
-    public void givenNegativeRepId_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+     void givenNegativeRepId_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         createMeansAssessmentRequest.setRepId(-1000);
-        ValidationException validationException = Assert.assertThrows(ValidationException.class,
+        ValidationException validationException = assertThrows(ValidationException.class,
                 () -> meansAssessmentValidationProcessor.validate(createMeansAssessmentRequest, AssessmentRequestType.UPDATE));
         assertThat(validationException.getMessage()).isEqualTo(MSG_REP_ID_REQUIRED);
     }
 
     @Test
-    public void givenInvalidRoleReservation_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+     void givenInvalidRoleReservation_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         when(meansAssessmentValidationService.isRepOrderReserved(
                 any(MeansAssessmentRequestDTO.class))
         ).thenReturn(Boolean.FALSE);
 
-        ValidationException validationException = Assert.assertThrows(ValidationException.class,
+        ValidationException validationException = assertThrows(ValidationException.class,
                 () -> meansAssessmentValidationProcessor.validate(createMeansAssessmentRequest, AssessmentRequestType.UPDATE));
         assertThat(validationException.getMessage()).isEqualTo(MSG_RECORD_NOT_RESERVED_BY_CURRENT_USER);
     }
 
     @Test
-    public void givenInvalidRoleAction_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+     void givenInvalidRoleAction_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         when(meansAssessmentValidationService.isRoleActionValid(
                 any(MeansAssessmentRequestDTO.class), any(String.class))
         ).thenReturn(Boolean.FALSE);
 
-        ValidationException validationException = Assert.assertThrows(ValidationException.class,
+        ValidationException validationException = assertThrows(ValidationException.class,
                 () -> meansAssessmentValidationProcessor.validate(createMeansAssessmentRequest, AssessmentRequestType.UPDATE));
         assertThat(validationException.getMessage()).isEqualTo(MSG_ROLE_ACTION_IS_NOT_VALID);
     }
 
     @Test
-    public void givenOutstandingAssessment_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+     void givenOutstandingAssessment_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         when(meansAssessmentValidationService.isOutstandingAssessment(
                 any(MeansAssessmentRequestDTO.class))
         ).thenReturn(Boolean.TRUE);
 
-        ValidationException validationException = Assert.assertThrows(ValidationException.class,
+        ValidationException validationException = assertThrows(ValidationException.class,
                 () -> meansAssessmentValidationProcessor.validate(createMeansAssessmentRequest, AssessmentRequestType.CREATE));
         assertThat(validationException.getMessage()).isEqualTo(MSG_INCOMPLETE_ASSESSMENT_FOUND);
     }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/MeansAssessmentValidationProcessorTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/validator/MeansAssessmentValidationProcessorTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.*;
 import static uk.gov.justice.laa.crime.meansassessment.validation.validator.MeansAssessmentValidationProcessor.*;
 
 @ExtendWith(MockitoExtension.class)
- class MeansAssessmentValidationProcessorTest {
+class MeansAssessmentValidationProcessorTest {
 
     MeansAssessmentRequestDTO createMeansAssessmentRequest;
     MeansAssessmentRequestDTO fullAssessment;
@@ -38,7 +38,7 @@ import static uk.gov.justice.laa.crime.meansassessment.validation.validator.Mean
     private MeansAssessmentValidationProcessor meansAssessmentValidationProcessor;
 
     @BeforeEach
-     void setup() {
+    void setup() {
 
         when(meansAssessmentValidationService.isNewWorkReasonValid(
                 any(MeansAssessmentRequestDTO.class))
@@ -65,7 +65,7 @@ import static uk.gov.justice.laa.crime.meansassessment.validation.validator.Mean
     }
 
     @Test
-     void givenCreateInitAssessmentRequest_whenAllValidationsPass_thenValidatorDoesNotThrowException() {
+    void givenCreateInitAssessmentRequest_whenAllValidationsPass_thenValidatorDoesNotThrowException() {
         Optional<Void> result =
                 meansAssessmentValidationProcessor.validate(createMeansAssessmentRequest, AssessmentRequestType.CREATE);
 
@@ -81,7 +81,7 @@ import static uk.gov.justice.laa.crime.meansassessment.validation.validator.Mean
     }
 
     @Test
-     void givenUpdateFullAssessmentRequest_whenAllValidationsPass_thenValidatorDoesNotThrowException() {
+    void givenUpdateFullAssessmentRequest_whenAllValidationsPass_thenValidatorDoesNotThrowException() {
         fullAssessment.setFullAssessmentDate(LocalDateTime.now());
         Optional<Void> result = meansAssessmentValidationProcessor.validate(fullAssessment, AssessmentRequestType.UPDATE);
 
@@ -96,7 +96,7 @@ import static uk.gov.justice.laa.crime.meansassessment.validation.validator.Mean
     }
 
     @Test
-     void givenInitAssessmentValidationFailure_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+    void givenInitAssessmentValidationFailure_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         when(initAssessmentValidator.validate(
                 any(MeansAssessmentRequestDTO.class))
         ).thenReturn(Boolean.FALSE);
@@ -107,7 +107,7 @@ import static uk.gov.justice.laa.crime.meansassessment.validation.validator.Mean
     }
 
     @Test
-     void givenFullAssessmentValidationFailure_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+    void givenFullAssessmentValidationFailure_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         when(fullAssessmentValidator.validate(
                 any(MeansAssessmentRequestDTO.class)
         )).thenReturn(Boolean.FALSE);
@@ -118,7 +118,7 @@ import static uk.gov.justice.laa.crime.meansassessment.validation.validator.Mean
     }
 
     @Test
-     void givenInvalidNewWorkReason_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+    void givenInvalidNewWorkReason_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         when(meansAssessmentValidationService.isNewWorkReasonValid(
                 any(MeansAssessmentRequestDTO.class))
         ).thenReturn(Boolean.FALSE);
@@ -129,7 +129,7 @@ import static uk.gov.justice.laa.crime.meansassessment.validation.validator.Mean
     }
 
     @Test
-     void givenNullRepId_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+    void givenNullRepId_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         createMeansAssessmentRequest = TestModelDataBuilder.getMeansAssessmentRequestDTO(false);
         ValidationException validationException = assertThrows(ValidationException.class,
                 () -> meansAssessmentValidationProcessor.validate(createMeansAssessmentRequest, AssessmentRequestType.UPDATE));
@@ -137,7 +137,7 @@ import static uk.gov.justice.laa.crime.meansassessment.validation.validator.Mean
     }
 
     @Test
-     void givenNegativeRepId_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+    void givenNegativeRepId_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         createMeansAssessmentRequest.setRepId(-1000);
         ValidationException validationException = assertThrows(ValidationException.class,
                 () -> meansAssessmentValidationProcessor.validate(createMeansAssessmentRequest, AssessmentRequestType.UPDATE));
@@ -145,7 +145,7 @@ import static uk.gov.justice.laa.crime.meansassessment.validation.validator.Mean
     }
 
     @Test
-     void givenInvalidRoleReservation_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+    void givenInvalidRoleReservation_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         when(meansAssessmentValidationService.isRepOrderReserved(
                 any(MeansAssessmentRequestDTO.class))
         ).thenReturn(Boolean.FALSE);
@@ -156,7 +156,7 @@ import static uk.gov.justice.laa.crime.meansassessment.validation.validator.Mean
     }
 
     @Test
-     void givenInvalidRoleAction_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+    void givenInvalidRoleAction_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         when(meansAssessmentValidationService.isRoleActionValid(
                 any(MeansAssessmentRequestDTO.class), any(String.class))
         ).thenReturn(Boolean.FALSE);
@@ -167,7 +167,7 @@ import static uk.gov.justice.laa.crime.meansassessment.validation.validator.Mean
     }
 
     @Test
-     void givenOutstandingAssessment_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
+    void givenOutstandingAssessment_whenValidateIsInvoked_thenCorrectExceptionIsThrown() {
         when(meansAssessmentValidationService.isOutstandingAssessment(
                 any(MeansAssessmentRequestDTO.class))
         ).thenReturn(Boolean.TRUE);


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-710)

Remove all references to JUnit 4 library
- remove public modifiers from classes and methods
- update library imports for annotations such as @Test to  import org.junit.jupiter.api.Test;
- Replace @Before to @BeforeEach
- Replace @RunWith(SpringRunner.class) with @ExtendWith(SpringExtension.class)
- @Ignore to @Disabled
- Replace @RunWith(MockitoJUnitRunner.class) with @ExtendWith(MockitoExtension.class)

junit 4 still exists in classpath as it is required by MockWebserver. This will be removed [here](https://dsdmoj.atlassian.net/browse/LCAM-860) by replacing mockwebserver with wiremock

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
