### PR TITLE
LCAM-985: Upgraded crime commons version and enabled micrometer tracing

### DIFF
--- a/crime-means-assessment/build.gradle
+++ b/crime-means-assessment/build.gradle
@@ -16,7 +16,7 @@ def versions = [
         okhttpVersion               : "4.9.3",
         mockwebserverVersion        : "4.9.3",
         liquibase                   : "4.20.0",
-        crimeCommonsVersion         : "2.2.0",
+        crimeCommonsVersion         : "2.7.0",
         mockitoInlineVersion        : "5.2.0",
         cucumberVersion             : "7.14.0",
         springCloudStubRunnerVersion: "4.0.4"

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/CrimeMeansAssessmentApplication.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/CrimeMeansAssessmentApplication.java
@@ -1,13 +1,14 @@
 package uk.gov.justice.laa.crime.meansassessment;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
 @ConfigurationPropertiesScan
-@EnableAspectJAutoProxy(proxyTargetClass=true)
+@EnableAspectJAutoProxy(proxyTargetClass = true)
 public class CrimeMeansAssessmentApplication {
 
     public static void main(String[] args) {

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/dto/ErrorDTO.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/dto/ErrorDTO.java
@@ -6,6 +6,7 @@ import lombok.Value;
 @Value
 @Builder
 public class ErrorDTO {
+    private String traceId;
     private String code;
     private String message;
 }

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/exception/RestControllerAdviser.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/exception/RestControllerAdviser.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.crime.meansassessment.exception;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -8,46 +9,50 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import uk.gov.justice.laa.crime.commons.tracing.TraceIdHandler;
 import uk.gov.justice.laa.crime.meansassessment.dto.ErrorDTO;
 
 @RestControllerAdvice
 @Slf4j
+@RequiredArgsConstructor
 public class RestControllerAdviser {
+
+    private final TraceIdHandler traceIdHandler;
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseEntity<ErrorDTO> adviceBadRequests(MethodArgumentNotValidException ex) {
         log.error("Bad request is passed in: ", ex);
-        return getNewErrorResponseWith(HttpStatus.BAD_REQUEST, String.valueOf(ex.getBindingResult()));
+        return getNewErrorResponseWith(HttpStatus.BAD_REQUEST, String.valueOf(ex.getBindingResult()), traceIdHandler.getTraceId());
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseEntity<ErrorDTO> adviceParseError(HttpMessageNotReadableException ex) {
         log.error("Failed to parse request JSON: ", ex);
-        return getNewErrorResponseWith(HttpStatus.BAD_REQUEST, ex.getMessage());
+        return getNewErrorResponseWith(HttpStatus.BAD_REQUEST, ex.getMessage(), traceIdHandler.getTraceId());
     }
 
     @ExceptionHandler(APIClientException.class)
     public ResponseEntity<ErrorDTO> handleApiClientError(APIClientException ex) {
         log.error("APIClientException: ", ex);
-        return getNewErrorResponseWith(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+        return getNewErrorResponseWith(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), traceIdHandler.getTraceId());
     }
 
     @ExceptionHandler(ValidationException.class)
     public ResponseEntity<ErrorDTO> handleValidationError(ValidationException ex) {
         log.error("ValidationException: ", ex);
-        return getNewErrorResponseWith(HttpStatus.BAD_REQUEST, ex.getMessage());
+        return getNewErrorResponseWith(HttpStatus.BAD_REQUEST, ex.getMessage(), traceIdHandler.getTraceId());
     }
 
     @ExceptionHandler(RuntimeException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ResponseEntity<ErrorDTO> adviceServiceErrors(RuntimeException ex) {
         log.error("Service is failed due to in internal error.", ex);
-        return getNewErrorResponseWith(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+        return getNewErrorResponseWith(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), traceIdHandler.getTraceId());
     }
 
-    private static ResponseEntity<ErrorDTO> getNewErrorResponseWith(HttpStatus status, String errorMessage){
-        return new ResponseEntity<>(ErrorDTO.builder().code(status.toString()).message(errorMessage).build(), status);
+    private static ResponseEntity<ErrorDTO> getNewErrorResponseWith(HttpStatus status, String errorMessage, String traceId) {
+        return new ResponseEntity<>(ErrorDTO.builder().traceId(traceId).code(status.toString()).message(errorMessage).build(), status);
     }
 }

--- a/crime-means-assessment/src/main/resources/application.yaml
+++ b/crime-means-assessment/src/main/resources/application.yaml
@@ -14,6 +14,9 @@ management:
     web:
       exposure:
         include: health,info,metrics,prometheus
+  tracing:
+    propagation:
+      type: w3c,b3
 
 maatApi:
   oAuthEnabled: true

--- a/crime-means-assessment/src/main/resources/logback.xml
+++ b/crime-means-assessment/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} traceId: %X{traceId:-} spanId: %X{spanId:-} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentSectionSummaryBuilderTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentSectionSummaryBuilderTest.java
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.justice.laa.crime.meansassessment.CrimeMeansAssessmentApplication;
+import uk.gov.justice.laa.crime.meansassessment.config.CrimeMeansAssessmentTestConfiguration;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.AssessmentDTO;
 import uk.gov.justice.laa.crime.meansassessment.dto.maatcourtdata.FinancialAssessmentDTO;
@@ -24,6 +26,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder.*;
 
 @ExtendWith(SpringExtension.class)
+@Import(CrimeMeansAssessmentTestConfiguration.class)
 @SpringBootTest(classes = {CrimeMeansAssessmentApplication.class})
 class MeansAssessmentSectionSummaryBuilderTest {
 

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/config/CrimeMeansAssessmentTestConfiguration.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/config/CrimeMeansAssessmentTestConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.crime.meansassessment.config;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
@@ -9,6 +10,7 @@ import java.time.Instant;
 import java.util.Map;
 
 @TestConfiguration
+@ComponentScan(basePackages = {"uk.gov.justice.laa.crime.commons.tracing"})
 public class CrimeMeansAssessmentTestConfiguration {
 
     static final String SUB = "sub";

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/MeansAssessmentControllerTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/MeansAssessmentControllerTest.java
@@ -7,12 +7,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.justice.laa.crime.meansassessment.builder.MeansAssessmentRequestDTOBuilder;
+import uk.gov.justice.laa.crime.meansassessment.config.CrimeMeansAssessmentTestConfiguration;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
 import uk.gov.justice.laa.crime.meansassessment.model.common.ApiCreateMeansAssessmentRequest;
@@ -35,6 +37,7 @@ import static uk.gov.justice.laa.crime.meansassessment.util.RequestBuilderUtils.
 @DirtiesContext
 @ExtendWith(SpringExtension.class)
 @AutoConfigureMockMvc(addFilters = false)
+@Import(CrimeMeansAssessmentTestConfiguration.class)
 @WebMvcTest(MeansAssessmentController.class)
 class MeansAssessmentControllerTest {
 

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/StatelessMeansAssessmentControllerTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/StatelessMeansAssessmentControllerTest.java
@@ -7,10 +7,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.justice.laa.crime.meansassessment.config.CrimeMeansAssessmentTestConfiguration;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.model.common.ApiMeansAssessmentRequest;
 import uk.gov.justice.laa.crime.meansassessment.model.common.stateless.Assessment;
@@ -37,6 +39,7 @@ import static uk.gov.justice.laa.crime.meansassessment.util.RequestBuilderUtils.
 
 @ExtendWith(SpringExtension.class)
 @AutoConfigureMockMvc(addFilters = false)
+@Import(CrimeMeansAssessmentTestConfiguration.class)
 @WebMvcTest(StatelessMeansAssessmentController.class)
 class StatelessMeansAssessmentControllerTest {
     private static final String MEANS_ASSESSMENT_ENDPOINT_URL = "/api/internal/v2/assessment/means";

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/factory/MeansAssessmentServiceFactoryTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/factory/MeansAssessmentServiceFactoryTest.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.justice.laa.crime.meansassessment.config.CrimeMeansAssessmentTestConfiguration;
 import uk.gov.justice.laa.crime.meansassessment.service.FullMeansAssessmentService;
 import uk.gov.justice.laa.crime.meansassessment.service.InitMeansAssessmentService;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.AssessmentType;
@@ -12,6 +14,7 @@ import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.AssessmentType;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest()
+@Import(CrimeMeansAssessmentTestConfiguration.class)
 @ExtendWith(SpringExtension.class)
 class MeansAssessmentServiceFactoryTest {
 


### PR DESCRIPTION
## What

[LCAM-985](https://dsdmoj.atlassian.net/browse/LCAM-985)

Describe what you did and why.

- Upgraded crime commons library to v2.7.0 to include micrometer tracing
- Updated Exception handler to include traceId in error response
- Updated application.yaml to enable micrometer tracing for CMA
- Updated logback.xml to include traceId and spanId
- Updated controller and Integration tests

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.


[LCAM-985]: https://dsdmoj.atlassian.net/browse/LCAM-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ