### PR TITLE
LCAM 1007 Clean Up Gradle Build File

### DIFF
--- a/crime-means-assessment/build.gradle
+++ b/crime-means-assessment/build.gradle
@@ -10,7 +10,6 @@ plugins {
 }
 
 def versions = [
-        mapstructVersion            : '1.3.1.Final',
         pitest                      : "1.4.10",
         springdocVersion            : "2.1.0",
         okhttpVersion               : "4.9.3",
@@ -19,6 +18,7 @@ def versions = [
         crimeCommonsVersion         : "2.7.0",
         mockitoInlineVersion        : "5.2.0",
         cucumberVersion             : "7.14.0",
+        jUnitPlatformSuiteVersion   : "1.10.0",
         springCloudStubRunnerVersion: "4.0.4"
 ]
 
@@ -43,12 +43,9 @@ dependencies {
     implementation("io.sentry:sentry-spring-boot-starter")
     implementation("io.sentry:sentry-logback")
 
-    implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation "org.springframework.boot:spring-boot-starter-webflux"
     implementation "org.springframework.boot:spring-boot-starter-actuator"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-validation"
-    implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
     implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
 
     implementation "org.postgresql:postgresql"
@@ -62,9 +59,6 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok"
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
-    implementation "org.mapstruct:mapstruct:$versions.mapstructVersion"
-    annotationProcessor "org.mapstruct:mapstruct-processor:$versions.mapstructVersion"
-
     testImplementation "com.h2database:h2"
     testImplementation "org.mockito:mockito-inline:$versions.mockitoInlineVersion"
     testImplementation "org.pitest:pitest:$versions.pitest"
@@ -75,10 +69,10 @@ dependencies {
 
     //  cucumber
     testImplementation platform("io.cucumber:cucumber-bom:$versions.cucumberVersion")
-    testImplementation "io.cucumber:cucumber-java:$versions.cucumberVersion"
-    testImplementation "io.cucumber:cucumber-spring:$versions.cucumberVersion"
-    testImplementation "io.cucumber:cucumber-junit-platform-engine:$versions.cucumberVersion"
-    testImplementation 'org.junit.platform:junit-platform-suite:1.10.0'
+    testImplementation "io.cucumber:cucumber-java"
+    testImplementation "io.cucumber:cucumber-spring"
+    testImplementation "io.cucumber:cucumber-junit-platform-engine"
+    testImplementation "org.junit.platform:junit-platform-suite:$versions.jUnitPlatformSuiteVersion"
 }
 
 configurations {


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1007)

See Jira ticket for detailed list of changes.

NOTE: Left `spring-boot-starter-actuator` in build file as Sris tracing changes depended on it, and it's not included in the crime commons dependency as a fatjar (including it's dependencies) isn't created when building crime commons.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
