### PR TITLE
LCAM-1005|Remove laaTransactionId from Court Data API calls

### DIFF
--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentRequestDTOBuilder.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentRequestDTOBuilder.java
@@ -14,7 +14,6 @@ public class MeansAssessmentRequestDTOBuilder {
     public MeansAssessmentRequestDTO buildRequestDTO(final ApiMeansAssessmentRequest assessmentRequest) {
 
         MeansAssessmentRequestDTO requestDTO = MeansAssessmentRequestDTO.builder()
-                .laaTransactionId(assessmentRequest.getLaaTransactionId())
                 .repId(assessmentRequest.getRepId())
                 .cmuId(assessmentRequest.getCmuId())
                 .initialAssessmentDate(assessmentRequest.getInitialAssessmentDate())

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/controller/MeansAssessmentController.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/controller/MeansAssessmentController.java
@@ -39,6 +39,7 @@ public class MeansAssessmentController {
     private final MeansAssessmentValidationProcessor meansAssessmentValidationProcessor;
 
     private MeansAssessmentRequestDTO preProcessRequest(ApiMeansAssessmentRequest meansAssessment, AssessmentRequestType requestType) {
+        log.info("Means assessment request received with transaction id - " + meansAssessment.getLaaTransactionId());
         MeansAssessmentRequestDTO requestDTO =
                 meansAssessmentRequestDTOBuilder.buildRequestDTO(meansAssessment);
         meansAssessmentValidationProcessor.validate(requestDTO, requestType);
@@ -130,8 +131,8 @@ public class MeansAssessmentController {
     )
     public ResponseEntity<ApiGetMeansAssessmentResponse> getOldAssessment(@PathVariable int financialAssessmentId,
                                                                           @Parameter(description = "Used for tracing calls") @RequestHeader(value = "Laa-Transaction-Id", required = false) String laaTransactionId) {
-        log.info("Get old means assessment request received");
-        return ResponseEntity.ok(meansAssessmentService.getOldAssessment(financialAssessmentId, laaTransactionId));
+        log.info("Get old means assessment request received with transaction id - " + laaTransactionId);
+        return ResponseEntity.ok(meansAssessmentService.getOldAssessment(financialAssessmentId));
     }
 
 
@@ -144,6 +145,5 @@ public class MeansAssessmentController {
         log.info("Retrieve full assessment threshold");
         return ResponseEntity.ok(assessmentCriteriaService.getFullAssessmentThreshold(assessmentDate));
     }
-
 
 }

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/dto/MeansAssessmentRequestDTO.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/dto/MeansAssessmentRequestDTO.java
@@ -12,7 +12,6 @@ import java.util.List;
 @Data
 @Builder
 public class MeansAssessmentRequestDTO {
-    private String laaTransactionId;
     private Integer repId;
     private Integer cmuId;
     private LocalDateTime initialAssessmentDate;

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCompletionService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCompletionService.java
@@ -18,7 +18,7 @@ public class AssessmentCompletionService {
 
     private final MaatCourtDataService maatCourtDataService;
 
-    public void execute(MeansAssessmentDTO assessment, String laaTransactionId) {
+    public void execute(MeansAssessmentDTO assessment) {
         boolean isUpdateRequired = false;
         MeansAssessmentRequestDTO meansAssessmentRequest = assessment.getMeansAssessment();
         CurrentStatus assessmentStatus = meansAssessmentRequest.getAssessmentStatus();
@@ -32,18 +32,18 @@ public class AssessmentCompletionService {
         }
 
         if (isUpdateRequired) {
-            updateApplicationCompletionDate(assessment, laaTransactionId);
+            updateApplicationCompletionDate(assessment);
         }
     }
 
-    void updateApplicationCompletionDate(MeansAssessmentDTO assessment, String laaTransactionId) {
+    void updateApplicationCompletionDate(MeansAssessmentDTO assessment) {
         assessment.setDateCompleted(LocalDateTime.now());
         DateCompletionRequestDTO dateCompletionRequestDTO = DateCompletionRequestDTO
                 .builder()
                 .repId(assessment.getMeansAssessment().getRepId())
                 .assessmentDateCompleted(assessment.getDateCompleted())
                 .build();
-        RepOrderDTO response = maatCourtDataService.updateCompletionDate(dateCompletionRequestDTO, laaTransactionId);
+        RepOrderDTO response = maatCourtDataService.updateCompletionDate(dateCompletionRequestDTO);
         assessment.setApplicationTimestamp(response.getDateModified());
     }
 

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityService.java
@@ -23,12 +23,11 @@ public class CrownCourtEligibilityService implements EligibilityChecker {
     private final MaatCourtDataService maatCourtDataService;
 
     public boolean isEligibilityCheckRequired(MeansAssessmentRequestDTO assessmentRequest) {
-        String laaTransactionId = assessmentRequest.getLaaTransactionId();
 
         boolean isEitherWayAndCommittedForTrial =
                 CaseType.EITHER_WAY.equals(assessmentRequest.getCaseType())
                         && MagCourtOutcome.COMMITTED_FOR_TRIAL.equals(assessmentRequest.getMagCourtOutcome());
-        RepOrderDTO repOrder = maatCourtDataService.getRepOrder(assessmentRequest.getRepId(), laaTransactionId);
+        RepOrderDTO repOrder = maatCourtDataService.getRepOrder(assessmentRequest.getRepId());
 
         if (isEitherWayAndCommittedForTrial) {
             Integer financialAssessmentId = assessmentRequest.getFinancialAssessmentId();

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/MaatCourtDataService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/MaatCourtDataService.java
@@ -26,7 +26,6 @@ public class MaatCourtDataService {
     private final RestAPIClient maatAPIClient;
 
     public MaatApiAssessmentResponse persistMeansAssessment(MaatApiAssessmentRequest assessment,
-                                                            String laaTransactionId,
                                                             AssessmentRequestType requestType) {
         MaatApiAssessmentResponse response;
         String endpoint = configuration.getFinancialAssessmentEndpoints().getByRequestType(requestType);
@@ -34,69 +33,64 @@ public class MaatCourtDataService {
             response =
                     maatAPIClient.post(assessment, new ParameterizedTypeReference<>() {},
                             endpoint,
-                            Map.of(Constants.LAA_TRANSACTION_ID, laaTransactionId));
+                            Map.of());
         } else {
             response =
                     maatAPIClient.put(assessment, new ParameterizedTypeReference<>() {},
                             endpoint,
-                            Map.of(Constants.LAA_TRANSACTION_ID, laaTransactionId));
+                            Map.of());
         }
         log.info(String.format(RESPONSE_STRING, response));
         return response;
     }
 
-    public RepOrderDTO updateCompletionDate(DateCompletionRequestDTO dateCompletionRequestDTO, String laaTransactionId) {
+    public RepOrderDTO updateCompletionDate(DateCompletionRequestDTO dateCompletionRequestDTO) {
         RepOrderDTO response = maatAPIClient.post(dateCompletionRequestDTO, new ParameterizedTypeReference<>() {},
                 configuration.getRepOrderEndpoints().getDateCompletionUrl(),
-                Map.of(Constants.LAA_TRANSACTION_ID, laaTransactionId));
+                Map.of());
         log.info(String.format(RESPONSE_STRING, response));
         return response;
     }
 
-    public PassportAssessmentDTO getPassportAssessmentFromRepId(Integer repId, String laaTransactionId) {
+    public PassportAssessmentDTO getPassportAssessmentFromRepId(Integer repId) {
         PassportAssessmentDTO response = maatAPIClient.get(new ParameterizedTypeReference<>() {},
                 configuration.getPassportAssessmentEndpoints().getFindUrl(),
-                Map.of(Constants.LAA_TRANSACTION_ID, laaTransactionId),
                 repId
         );
         log.info(String.format(RESPONSE_STRING, response));
         return response;
     }
 
-    public HardshipReviewDTO getHardshipReviewFromRepId(Integer repId, String laaTransactionId) {
+    public HardshipReviewDTO getHardshipReviewFromRepId(Integer repId) {
         HardshipReviewDTO response = maatAPIClient.get(new ParameterizedTypeReference<>() {},
                 configuration.getHardshipReviewEndpoints().getFindUrl(),
-                Map.of(Constants.LAA_TRANSACTION_ID, laaTransactionId),
                 repId
         );
         log.info(String.format(RESPONSE_STRING, response));
         return response;
     }
 
-    public IOJAppealDTO getIOJAppealFromRepId(Integer repId, String laaTransactionId) {
+    public IOJAppealDTO getIOJAppealFromRepId(Integer repId) {
         IOJAppealDTO response = maatAPIClient.get(new ParameterizedTypeReference<>() {},
                 configuration.getIojAppealEndpoints().getFindUrl(),
-                Map.of(Constants.LAA_TRANSACTION_ID, laaTransactionId),
                 repId
         );
         log.info(String.format(RESPONSE_STRING, response));
         return response;
     }
 
-    public FinancialAssessmentDTO getFinancialAssessment(Integer financialAssessmentId, String laaTransactionId) {
+    public FinancialAssessmentDTO getFinancialAssessment(Integer financialAssessmentId) {
         FinancialAssessmentDTO response = maatAPIClient.get(new ParameterizedTypeReference<>() {},
                 configuration.getFinancialAssessmentEndpoints().getSearchUrl(),
-                Map.of(Constants.LAA_TRANSACTION_ID, laaTransactionId),
                 financialAssessmentId
         );
         log.info(String.format(RESPONSE_STRING, response));
         return response;
     }
 
-    public RepOrderDTO getRepOrder(Integer repId, String laaTransactionId) {
+    public RepOrderDTO getRepOrder(Integer repId) {
         RepOrderDTO response = maatAPIClient.get(new ParameterizedTypeReference<>() {},
                 configuration.getRepOrderEndpoints().getFindUrl(),
-                Map.of(Constants.LAA_TRANSACTION_ID, laaTransactionId),
                 repId
         );
         log.info(String.format(RESPONSE_STRING, response));

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/MeansAssessmentService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/service/MeansAssessmentService.java
@@ -95,12 +95,11 @@ public class MeansAssessmentService extends BaseMeansAssessmentService {
             completedAssessment.setMeansAssessment(requestDTO);
             completedAssessment.setAssessmentCriteria(assessmentCriteria);
 
-            assessmentCompletionService.execute(completedAssessment, requestDTO.getLaaTransactionId());
+            assessmentCompletionService.execute(completedAssessment);
 
             MaatApiAssessmentResponse maatApiAssessmentResponse =
                     maatCourtDataService.persistMeansAssessment(
                             assessmentBuilder.build(completedAssessment, requestType),
-                            requestDTO.getLaaTransactionId(),
                             requestType
                     );
             log.info("Posting completed means assessment to Court Data API");
@@ -140,11 +139,11 @@ public class MeansAssessmentService extends BaseMeansAssessmentService {
         }
     }
 
-    public ApiGetMeansAssessmentResponse getOldAssessment(Integer financialAssessmentId, String laaTransactionId) {
+    public ApiGetMeansAssessmentResponse getOldAssessment(Integer financialAssessmentId) {
         log.info("Processing get old assessment request - Start");
         ApiGetMeansAssessmentResponse assessmentResponse = null;
         FinancialAssessmentDTO financialAssessmentDTO =
-                maatCourtDataService.getFinancialAssessment(financialAssessmentId, laaTransactionId);
+                maatCourtDataService.getFinancialAssessment(financialAssessmentId);
         if (null != financialAssessmentDTO) {
             assessmentResponse = new ApiGetMeansAssessmentResponse();
             buildMeansAssessmentResponse(assessmentResponse, financialAssessmentDTO);

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/validation/service/MeansAssessmentValidationService.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/validation/service/MeansAssessmentValidationService.java
@@ -40,7 +40,6 @@ public class MeansAssessmentValidationService {
         if (StringUtils.isNotBlank(getUserIdFromRequest(meansAssessmentRequest)) && StringUtils.isNotBlank(action)) {
             AuthorizationResponseDTO apiResponse = maatAPIClient.get(new ParameterizedTypeReference<>() {},
                     configuration.getValidationEndpoints().getRoleActionUrl(),
-                    Map.of(LAA_TRANSACTION_ID, meansAssessmentRequest.getLaaTransactionId()),
                     getUserIdFromRequest(meansAssessmentRequest),
                     action
             );
@@ -53,7 +52,6 @@ public class MeansAssessmentValidationService {
         if (meansAssessmentRequest.getNewWorkReason() != null) {
             AuthorizationResponseDTO apiResponse = maatAPIClient.get(new ParameterizedTypeReference<>() {},
                     configuration.getValidationEndpoints().getNewWorkReasonUrl(),
-                    Map.of(LAA_TRANSACTION_ID, meansAssessmentRequest.getLaaTransactionId()),
                     getUserIdFromRequest(meansAssessmentRequest),
                     meansAssessmentRequest.getNewWorkReason().getCode()
             );
@@ -66,7 +64,6 @@ public class MeansAssessmentValidationService {
         if (meansAssessmentRequest.getRepId() != null) {
             OutstandingAssessmentResultDTO apiResponse = maatAPIClient.get(new ParameterizedTypeReference<>() {},
                     configuration.getValidationEndpoints().getOutstandingAssessmentsUrl(),
-                    Map.of(LAA_TRANSACTION_ID, meansAssessmentRequest.getLaaTransactionId()),
                     meansAssessmentRequest.getRepId()
             );
             return apiResponse.isOutstandingAssessments();
@@ -80,7 +77,6 @@ public class MeansAssessmentValidationService {
                 && meansAssessmentRequest.getRepId() != null) {
             AuthorizationResponseDTO apiResponse = maatAPIClient.get(new ParameterizedTypeReference<>() {},
                     configuration.getValidationEndpoints().getReservationsUrl(),
-                    Map.of(LAA_TRANSACTION_ID, meansAssessmentRequest.getLaaTransactionId()),
                     getUserIdFromRequest(meansAssessmentRequest),
                     meansAssessmentRequest.getRepId(),
                     meansAssessmentRequest.getUserSession().getSessionId()

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentRequestDTOBuilderTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentRequestDTOBuilderTest.java
@@ -23,7 +23,6 @@ class MeansAssessmentRequestDTOBuilderTest {
         MeansAssessmentRequestDTO resultDto = requestDTOBuilder.buildRequestDTO(meansAssessment);
 
         SoftAssertions.assertSoftly(softly -> {
-            assertThat(resultDto.getLaaTransactionId()).isEqualTo(meansAssessment.getLaaTransactionId());
             assertThat(resultDto.getRepId()).isEqualTo(meansAssessment.getRepId());
             assertThat(resultDto.getCmuId()).isEqualTo(meansAssessment.getCmuId());
             assertThat(resultDto.getInitialAssessmentDate()).isEqualTo(meansAssessment.getInitialAssessmentDate());

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/MeansAssessmentControllerTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/controller/MeansAssessmentControllerTest.java
@@ -161,7 +161,7 @@ class MeansAssessmentControllerTest {
 
     @Test
     void givenValidParam_whenGetOldAssessmentInvoked_shouldSuccess() throws Exception {
-        when(meansAssessmentService.getOldAssessment(any(), any())).thenReturn(new ApiGetMeansAssessmentResponse());
+        when(meansAssessmentService.getOldAssessment(any())).thenReturn(new ApiGetMeansAssessmentResponse());
         mvc.perform(buildRequestGivenContent(
                 HttpMethod.GET,
                 "",

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/data/builder/TestModelDataBuilder.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/data/builder/TestModelDataBuilder.java
@@ -1,7 +1,9 @@
 package uk.gov.justice.laa.crime.meansassessment.data.builder;
 
 import org.springframework.stereotype.Component;
-import uk.gov.justice.laa.crime.meansassessment.dto.*;
+import uk.gov.justice.laa.crime.meansassessment.dto.AssessmentDTO;
+import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentDTO;
+import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
 import uk.gov.justice.laa.crime.meansassessment.dto.maatcourtdata.*;
 import uk.gov.justice.laa.crime.meansassessment.model.common.*;
 import uk.gov.justice.laa.crime.meansassessment.model.common.maatapi.MaatApiAssessmentResponse;
@@ -12,12 +14,8 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 @Component
 public class TestModelDataBuilder {
@@ -95,7 +93,6 @@ public class TestModelDataBuilder {
     public static final String MEANS_ASSESSMENT_TRANSACTION_ID = "7c49ebfe-fe3a-4f2f-8dad-f7b8f03b8327";
     public static final Integer TEST_ASSESSMENT_DETAILS_ID = 41681819;
     public static final String TEST_ASSESSMENT_TYPE_INIT = "INIT";
-    public static final String TEST_ASSESSMENT_TYPE_FULL = "FULL";
     public static final String TEST_ASSESSMENT_SECTION_INITA = "INITA";
     public static final String TEST_ASSESSMENT_SECTION_INITB = "INITB";
     public static final String TEST_ASSESSMENT_SECTION_FULLA = "FULLA";
@@ -104,8 +101,6 @@ public class TestModelDataBuilder {
     private static final Integer TEST_FINANCIAL_ASSESSMENT_ID = 63423;
 
     public static final String TEST_DATE_STRING = "2022-10-08";
-
-    public static final String MAAT_API_REGISTRATION_ID = "maat-api";
 
     public static AssessmentCriteriaEntity getAssessmentCriteriaEntityWithChildWeightings(BigDecimal[] weightingFactors) {
         var criteria = getAssessmentCriteriaEntity();
@@ -156,17 +151,6 @@ public class TestModelDataBuilder {
                 .upperAgeRange(TEST_INITIAL_UPPER_AGE_RANGE)
                 .weightingFactor(TEST_WEIGHTING_FACTOR)
                 .userCreated(TEST_USER)
-                .build();
-    }
-
-    public static AssessmentDetailEntity getAssessmentDetailEntity() {
-        return AssessmentDetailEntity.builder()
-                .detailCode(TEST_DETAIL_CODE)
-                .description(TEST_DESCRIPTION)
-                .createdDateTime(LocalDateTime.now())
-                .createdBy(TEST_USER)
-                .modifiedDateTime(LocalDateTime.now())
-                .modifiedBy(TEST_USER)
                 .build();
     }
 
@@ -310,7 +294,6 @@ public class TestModelDataBuilder {
 
     public static MeansAssessmentRequestDTO getMeansAssessmentRequestDTO(boolean isValid) {
         return MeansAssessmentRequestDTO.builder()
-                .laaTransactionId(MEANS_ASSESSMENT_TRANSACTION_ID)
                 .repId(isValid ? 91919 : null)
                 .cmuId(isValid ? 91919 : null)
                 .initialAssessmentDate(LocalDateTime.of(2021, 12, 16, 10, 0))
@@ -401,51 +384,6 @@ public class TestModelDataBuilder {
         );
     }
 
-    public static List<ApiAssessmentSectionSummary> getAllApiAssessmentSectionSummaries() {
-        return List.of(
-                new ApiAssessmentSectionSummary()
-                        .withSection("INITA")
-                        .withAssessmentDetails(
-                                List.of(
-                                        new ApiAssessmentDetail()
-                                                .withCriteriaDetailId(132)
-                                                .withApplicantAmount(TEST_APPLICANT_VALUE)
-                                                .withApplicantFrequency(TEST_FREQUENCY)
-                                        ,
-                                        new ApiAssessmentDetail()
-                                                .withCriteriaDetailId(133)
-                                                .withApplicantAmount(BigDecimal.ZERO)
-                                        ,
-                                        new ApiAssessmentDetail()
-                                                .withCriteriaDetailId(134)
-                                                .withApplicantAmount(BigDecimal.ZERO)
-                                                .withPartnerAmount(TEST_PARTNER_VALUE)
-                                                .withPartnerFrequency(TEST_FREQUENCY)
-                                )
-                        )
-                ,
-                new ApiAssessmentSectionSummary()
-                        .withSection("INITB")
-                        .withAssessmentDetails(
-                                Stream.of(
-                                        List.of(new ApiAssessmentDetail()
-                                                .withCriteriaDetailId(135)
-                                                .withApplicantAmount(TEST_APPLICANT_VALUE)
-                                                .withApplicantFrequency(TEST_FREQUENCY)
-                                                .withPartnerAmount(TEST_PARTNER_VALUE)
-                                                .withPartnerFrequency(TEST_FREQUENCY)),
-
-                                        IntStream.range(136, 146).boxed().collect(Collectors.toList())
-                                                .stream().map(num -> new ApiAssessmentDetail()
-                                                        .withCriteriaDetailId(num)
-                                                        .withApplicantAmount(TEST_APPLICANT_VALUE)
-                                                        .withApplicantFrequency(TEST_FREQUENCY)
-                                                ).collect(Collectors.toList())
-                                ).flatMap(Collection::stream).collect(Collectors.toList())
-                        )
-        );
-    }
-
     public static ApiUserSession getUserSession() {
         return new ApiUserSession()
                 .withSessionId("6c45ebfe-fe3a-5f2f-8dad-f7c8f03b8327")
@@ -490,14 +428,6 @@ public class TestModelDataBuilder {
                 .withAdjustedIncomeValue(TEST_ADJUSTED_INCOME)
                 .withTotalAnnualDisposableIncome(TEST_DISPOSABLE_INCOME)
                 .withTotalAggregatedExpense(TEST_TOTAL_EXPENDITURE);
-    }
-
-    public static AuthorizationResponseDTO getAuthorizationResponseDTO(boolean valid) {
-        return AuthorizationResponseDTO.builder().result(valid).build();
-    }
-
-    public static OutstandingAssessmentResultDTO getOutstandingAssessmentResultDTO(boolean outstandingAssessmentsFound) {
-        return OutstandingAssessmentResultDTO.builder().outstandingAssessments(outstandingAssessmentsFound).build();
     }
 
     public static List<ApiAssessmentSectionSummary> getApiAssessmentSummaries(boolean isValid) {

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCompletionServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/AssessmentCompletionServiceTest.java
@@ -10,20 +10,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentDTO;
 import uk.gov.justice.laa.crime.meansassessment.dto.maatcourtdata.DateCompletionRequestDTO;
-import uk.gov.justice.laa.crime.meansassessment.dto.maatcourtdata.FinancialAssessmentDTO;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AssessmentCompletionServiceTest {
 
-    private final String LAA_TRANSACTION_ID = "laa-transaction-id";
     private MeansAssessmentDTO assessment;
     @Spy
     @InjectMocks
@@ -40,10 +37,10 @@ class AssessmentCompletionServiceTest {
 
     @Test
     void givenAssessment_whenUpdateApplicationCompletionDateIsInvoked_thenCompletionDateIsPersisted() {
-        when(maatCourtDataService.updateCompletionDate(any(DateCompletionRequestDTO.class), anyString()))
+        when(maatCourtDataService.updateCompletionDate(any(DateCompletionRequestDTO.class)))
                 .thenReturn(TestModelDataBuilder.getRepOrderDTO());
 
-        assessmentCompletionService.updateApplicationCompletionDate(assessment, LAA_TRANSACTION_ID);
+        assessmentCompletionService.updateApplicationCompletionDate(assessment);
         assertThat(LocalDate.now()).isEqualTo(assessment.getDateCompleted().toLocalDate());
     }
 
@@ -99,9 +96,9 @@ class AssessmentCompletionServiceTest {
     @Test
     void givenIncompleteAssessment_whenExecuteIsInvoked_thenCompletionDateIsNotUpdated() {
         assessment.getMeansAssessment().setAssessmentStatus(CurrentStatus.IN_PROGRESS);
-        assessmentCompletionService.execute(assessment, LAA_TRANSACTION_ID);
+        assessmentCompletionService.execute(assessment);
         verify(maatCourtDataService, never())
-                .updateCompletionDate(any(DateCompletionRequestDTO.class), anyString());
+                .updateCompletionDate(any(DateCompletionRequestDTO.class));
     }
 
     @Test
@@ -109,10 +106,10 @@ class AssessmentCompletionServiceTest {
         doReturn(true)
                 .when(assessmentCompletionService).isInitAssessmentComplete(any(MeansAssessmentDTO.class));
 
-        when(maatCourtDataService.updateCompletionDate(any(DateCompletionRequestDTO.class), anyString()))
+        when(maatCourtDataService.updateCompletionDate(any(DateCompletionRequestDTO.class)))
                 .thenReturn(TestModelDataBuilder.getRepOrderDTO());
 
-        assessmentCompletionService.execute(assessment, LAA_TRANSACTION_ID);
+        assessmentCompletionService.execute(assessment);
         assertThat(LocalDate.now()).isEqualTo(assessment.getDateCompleted().toLocalDate());
     }
 
@@ -120,10 +117,10 @@ class AssessmentCompletionServiceTest {
     void givenCompleteFullAssessment_whenExecuteIsInvoked_thenCompletionDateIsUpdated() {
         assessment.getMeansAssessment().setAssessmentType(AssessmentType.FULL);
 
-        when(maatCourtDataService.updateCompletionDate(any(DateCompletionRequestDTO.class), anyString()))
+        when(maatCourtDataService.updateCompletionDate(any(DateCompletionRequestDTO.class)))
                 .thenReturn(TestModelDataBuilder.getRepOrderDTO());
 
-        assessmentCompletionService.execute(assessment, LAA_TRANSACTION_ID);
+        assessmentCompletionService.execute(assessment);
         assertThat(LocalDate.now()).isEqualTo(assessment.getDateCompleted().toLocalDate());
     }
 
@@ -132,10 +129,10 @@ class AssessmentCompletionServiceTest {
         assessment.getMeansAssessment().setAssessmentType(AssessmentType.FULL);
         assessment.getMeansAssessment().setAssessmentStatus(CurrentStatus.IN_PROGRESS);
 
-        assessmentCompletionService.execute(assessment, LAA_TRANSACTION_ID);
+        assessmentCompletionService.execute(assessment);
 
         assertThat(assessment.getDateCompleted()).isNull();
-        verify(maatCourtDataService, never()).updateCompletionDate(any(DateCompletionRequestDTO.class), anyString());
+        verify(maatCourtDataService, never()).updateCompletionDate(any(DateCompletionRequestDTO.class));
     }
 
 }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/CrownCourtEligibilityServiceTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, SoftAssertionsExtension.class})
@@ -50,7 +49,7 @@ class CrownCourtEligibilityServiceTest {
         requestDTO = TestModelDataBuilder.getMeansAssessmentRequestDTO(true);
         repOrderDTO = TestModelDataBuilder.getRepOrderDTOWithAssessments(new ArrayList<>(List.of(financialAssessment)));
 
-        when(maatCourtDataService.getRepOrder(anyInt(), anyString()))
+        when(maatCourtDataService.getRepOrder(anyInt()))
                 .thenReturn(repOrderDTO);
     }
 

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/MaatCourtDataServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/MaatCourtDataServiceTest.java
@@ -23,8 +23,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class MaatCourtDataServiceTest {
 
-    private static final String LAA_TRANSACTION_ID = "laaTransactionId";
-
     @Mock
     RestAPIClient maatAPIClient;
 
@@ -42,7 +40,7 @@ class MaatCourtDataServiceTest {
                 .thenReturn(expected);
 
         MaatApiAssessmentResponse response = maatCourtDataService.persistMeansAssessment(
-                new MaatApiAssessmentRequest(), LAA_TRANSACTION_ID, AssessmentRequestType.CREATE);
+                new MaatApiAssessmentRequest(), AssessmentRequestType.CREATE);
         assertThat(response).isEqualTo(expected);
     }
 
@@ -53,18 +51,18 @@ class MaatCourtDataServiceTest {
                 .thenReturn(expected);
 
         MaatApiAssessmentResponse response = maatCourtDataService.persistMeansAssessment(
-                new MaatApiAssessmentRequest(), LAA_TRANSACTION_ID, AssessmentRequestType.UPDATE);
+                new MaatApiAssessmentRequest(), AssessmentRequestType.UPDATE);
         assertThat(response).isEqualTo(expected);
     }
 
     @Test
     void givenRepId_whenGetPassportAssessmentFromRepIdIsInvoked_thenResponseIsReturned() {
         PassportAssessmentDTO expected = new PassportAssessmentDTO();
-        when(maatAPIClient.get(any(), anyString(), anyMap(), any()))
+        when(maatAPIClient.get(any(), anyString(), any()))
                 .thenReturn(expected);
 
         PassportAssessmentDTO response =
-                maatCourtDataService.getPassportAssessmentFromRepId(TestModelDataBuilder.TEST_REP_ID, LAA_TRANSACTION_ID);
+                maatCourtDataService.getPassportAssessmentFromRepId(TestModelDataBuilder.TEST_REP_ID);
 
         assertThat(response).isEqualTo(expected);
     }
@@ -72,11 +70,11 @@ class MaatCourtDataServiceTest {
     @Test
     void givenRepId_whenGetHardshipReviewFromRepIdIsInvoked_thenResponseIsReturned() {
         HardshipReviewDTO expected = new HardshipReviewDTO();
-        when(maatAPIClient.get(any(), anyString(), anyMap(), any()))
+        when(maatAPIClient.get(any(), anyString(), any()))
                 .thenReturn(expected);
 
         HardshipReviewDTO response =
-                maatCourtDataService.getHardshipReviewFromRepId(TestModelDataBuilder.TEST_REP_ID, LAA_TRANSACTION_ID);
+                maatCourtDataService.getHardshipReviewFromRepId(TestModelDataBuilder.TEST_REP_ID);
 
         assertThat(response).isEqualTo(expected);
     }
@@ -84,11 +82,11 @@ class MaatCourtDataServiceTest {
     @Test
     void givenRepId_whenGetIojAppealFromRepIdIsInvoked_thenResponseIsReturned() {
         IOJAppealDTO expected = new IOJAppealDTO();
-        when(maatAPIClient.get(any(), anyString(), anyMap(), any()))
+        when(maatAPIClient.get(any(), anyString(), any()))
                 .thenReturn(expected);
 
         IOJAppealDTO response =
-                maatCourtDataService.getIOJAppealFromRepId(TestModelDataBuilder.TEST_REP_ID, LAA_TRANSACTION_ID);
+                maatCourtDataService.getIOJAppealFromRepId(TestModelDataBuilder.TEST_REP_ID);
 
         assertThat(response).isEqualTo(expected);
     }
@@ -96,11 +94,11 @@ class MaatCourtDataServiceTest {
     @Test
     void givenRepId_whenGetFinancialAssessmentIsInvoked_thenResponseIsReturned() {
         FinancialAssessmentDTO expected = new FinancialAssessmentDTO();
-        when(maatAPIClient.get(any(), anyString(), anyMap(), any()))
+        when(maatAPIClient.get(any(), anyString(), any()))
                 .thenReturn(expected);
 
         FinancialAssessmentDTO response =
-                maatCourtDataService.getFinancialAssessment(TestModelDataBuilder.TEST_REP_ID, LAA_TRANSACTION_ID);
+                maatCourtDataService.getFinancialAssessment(TestModelDataBuilder.TEST_REP_ID);
 
         assertThat(response).isEqualTo(expected);
     }
@@ -108,18 +106,18 @@ class MaatCourtDataServiceTest {
     @Test
     void givenRepId_whenGetRepOrderIsInvoked_thenResponseIsReturned() {
         RepOrderDTO expected = new RepOrderDTO();
-        when(maatAPIClient.get(any(), anyString(), anyMap(), any()))
+        when(maatAPIClient.get(any(), anyString(), any()))
                 .thenReturn(expected);
 
         RepOrderDTO response =
-                maatCourtDataService.getRepOrder(TestModelDataBuilder.TEST_REP_ID, LAA_TRANSACTION_ID);
+                maatCourtDataService.getRepOrder(TestModelDataBuilder.TEST_REP_ID);
 
         assertThat(response).isEqualTo(expected);
     }
 
     @Test
     void givenDateCompletionRequest_whenUpdateCompletionDateIsInvoked_thenResponseIsReturned() {
-        maatCourtDataService.updateCompletionDate(DateCompletionRequestDTO.builder().build(), LAA_TRANSACTION_ID);
+        maatCourtDataService.updateCompletionDate(DateCompletionRequestDTO.builder().build());
         verify(maatAPIClient).post(
                 any(DateCompletionRequestDTO.class),
                 any(),

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/MeansAssessmentServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/service/MeansAssessmentServiceTest.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.meansassessment.builder.MaatCourtDataAssessmentBuilder;
 import uk.gov.justice.laa.crime.meansassessment.builder.MeansAssessmentResponseBuilder;
@@ -38,6 +41,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.*;
+import static uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder.MEANS_ASSESSMENT_ID;
 
 @ExtendWith(MockitoExtension.class)
 class MeansAssessmentServiceTest {
@@ -106,7 +110,7 @@ class MeansAssessmentServiceTest {
 
         MaatApiAssessmentResponse maatApiAssessmentResponse =
                 new MaatApiAssessmentResponse()
-                        .withId(TestModelDataBuilder.MEANS_ASSESSMENT_ID)
+                        .withId(MEANS_ASSESSMENT_ID)
                         .withInitTotAggregatedIncome(TestModelDataBuilder.TEST_AGGREGATED_INCOME)
                         .withInitResult(InitAssessmentResult.PASS.getResult())
                         .withInitResultReason(InitAssessmentResult.PASS.getReason())
@@ -114,7 +118,7 @@ class MeansAssessmentServiceTest {
                         .withFassInitStatus(TestModelDataBuilder.TEST_ASSESSMENT_STATUS.getStatus());
 
         when(maatCourtDataService.persistMeansAssessment(
-                any(MaatApiAssessmentRequest.class), anyString(), any(AssessmentRequestType.class))
+                any(MaatApiAssessmentRequest.class), any(AssessmentRequestType.class))
         ).thenReturn(maatApiAssessmentResponse);
 
         when(meansAssessmentResponseBuilder.build(any(MaatApiAssessmentResponse.class),
@@ -262,12 +266,10 @@ class MeansAssessmentServiceTest {
     @Test
     void givenInvalidAssessmentId_whenGetOldAssessmentInvoked_thenReturnEmpty() {
 
-        when(maatCourtDataService.getFinancialAssessment(any(), any())).thenReturn(null);
+        when(maatCourtDataService.getFinancialAssessment(any())).thenReturn(null);
         ApiGetMeansAssessmentResponse apiMeansAssessmentResponse =
-                meansAssessmentService.getOldAssessment(
-                        TestModelDataBuilder.MEANS_ASSESSMENT_ID, TestModelDataBuilder.MEANS_ASSESSMENT_TRANSACTION_ID
-                );
-        verify(maatCourtDataService, times(1)).getFinancialAssessment(any(), any());
+                meansAssessmentService.getOldAssessment(MEANS_ASSESSMENT_ID);
+        verify(maatCourtDataService, times(1)).getFinancialAssessment(any());
         assertThat(apiMeansAssessmentResponse).isNull();
 
     }
@@ -278,10 +280,10 @@ class MeansAssessmentServiceTest {
                 .when(assessmentCriteriaDetailService).getAssessmentCriteriaDetailById(any());
         when(meansAssessmentSectionSummaryBuilder.buildAssessmentDTO(any(), any())).thenReturn(TestModelDataBuilder
                 .getAssessmentDTO(TestModelDataBuilder.TEST_ASSESSMENT_TYPE_INIT, TestModelDataBuilder.TEST_SEQ));
-        when(maatCourtDataService.getFinancialAssessment(any(), any()))
+        when(maatCourtDataService.getFinancialAssessment(any()))
                 .thenReturn(TestModelDataBuilder.getFinancialAssessmentDTOWithDetails());
-        meansAssessmentService.getOldAssessment(TestModelDataBuilder.MEANS_ASSESSMENT_ID, TestModelDataBuilder.MEANS_ASSESSMENT_TRANSACTION_ID);
-        verify(maatCourtDataService, times(1)).getFinancialAssessment(any(), any());
+        meansAssessmentService.getOldAssessment(MEANS_ASSESSMENT_ID);
+        verify(maatCourtDataService, times(1)).getFinancialAssessment(any());
 
     }
 

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/service/MeansAssessmentValidationServiceTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/validation/service/MeansAssessmentValidationServiceTest.java
@@ -55,7 +55,7 @@ class MeansAssessmentValidationServiceTest {
     void givenInvalidNewWorkReason_whenIsNewWorkReasonValidIsInvoked_thenFalseIsReturned() {
         when(maatAPIClient.get(
                 eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {
-                }), anyString(), anyMap(), anyString(), anyString()))
+                }), anyString(), anyString(), anyString()))
                 .thenReturn(FALSE_AUTH_RESPONSE);
         assertThat(meansAssessmentValidationService.isNewWorkReasonValid(requestDTO)).isFalse();
     }
@@ -63,7 +63,7 @@ class MeansAssessmentValidationServiceTest {
     @Test
     void givenValidNewWorkReason_whenIsNewWorkReasonValidIsInvoked_thenTrueIsReturned() {
         when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {
-        }), anyString(), anyMap(), anyString(), anyString()))
+        }), anyString(), anyString(), anyString()))
                 .thenReturn(TRUE_AUTH_RESPONSE);
         assertThat(meansAssessmentValidationService.isNewWorkReasonValid(requestDTO)).isTrue();
     }
@@ -88,7 +88,7 @@ class MeansAssessmentValidationServiceTest {
     @Test
     void givenInvalidRoleAction_whenIsRoleActionValidIsInvoked_thenFalseIsReturned() {
         when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {
-        }), anyString(), anyMap(), anyString(), anyString()))
+        }), anyString(), anyString(), anyString()))
                 .thenReturn(FALSE_AUTH_RESPONSE);
         assertThat(meansAssessmentValidationService.isRoleActionValid(requestDTO, "FMA")).isFalse();
     }
@@ -96,7 +96,7 @@ class MeansAssessmentValidationServiceTest {
     @Test
     void givenValidRoleAction_whenIsRoleActionValidIsInvoked_thenTrueIsReturned() {
         when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {
-        }), anyString(), anyMap(), anyString(), anyString()))
+        }), anyString(), anyString(), anyString()))
                 .thenReturn(TRUE_AUTH_RESPONSE);
         assertThat(meansAssessmentValidationService.isRoleActionValid(requestDTO, "FMA")).isTrue();
     }
@@ -104,7 +104,7 @@ class MeansAssessmentValidationServiceTest {
     @Test
     void givenValidReservation_whenIsRepOrderReserved_thenTrueIsReturned() {
         when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {
-        }), anyString(), anyMap(), anyString(), anyInt(), anyString()))
+        }), anyString(), anyString(), anyInt(), anyString()))
                 .thenReturn(TRUE_AUTH_RESPONSE);
         assertThat(meansAssessmentValidationService.isRepOrderReserved(requestDTO)).isTrue();
     }
@@ -112,7 +112,7 @@ class MeansAssessmentValidationServiceTest {
     @Test
     void givenInvalidReservation_whenIsRepOrderReserved_thenFalseIsReturned() {
         when(maatAPIClient.get(eq(new ParameterizedTypeReference<AuthorizationResponseDTO>() {
-        }), anyString(), anyMap(), anyString(), anyInt(), anyString()))
+        }), anyString(), anyString(), anyInt(), anyString()))
                 .thenReturn(FALSE_AUTH_RESPONSE);
         assertThat(meansAssessmentValidationService.isRepOrderReserved(requestDTO)).isFalse();
     }
@@ -138,7 +138,7 @@ class MeansAssessmentValidationServiceTest {
     @Test
     void givenAnOutstandingAssessment_whenIsOutstandingAssessmentIsInvoked_thenTrueIsReturned() {
         when(maatAPIClient.get(eq(new ParameterizedTypeReference<OutstandingAssessmentResultDTO>() {
-        }), anyString(), anyMap(), any()))
+        }), anyString(), any()))
                 .thenReturn(IS_OUTSTANDING_ASSESSMENT);
         assertThat(meansAssessmentValidationService.isOutstandingAssessment(requestDTO)).isTrue();
     }
@@ -146,7 +146,7 @@ class MeansAssessmentValidationServiceTest {
     @Test
     void givenNoOutstandingAssessments_whenIsOutstandingAssessmentIsInvoked_thenFalseIsReturned() {
         when(maatAPIClient.get(eq(new ParameterizedTypeReference<OutstandingAssessmentResultDTO>() {
-        }), anyString(), anyMap(), any()))
+        }), anyString(), any()))
                 .thenReturn(NO_OUTSTANDING_ASSESSMENT);
         assertThat(meansAssessmentValidationService.isOutstandingAssessment(requestDTO)).isFalse();
     }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1005)

Removed laaTransactionId from Court Data API calls. Logging the laa-transaction-id in the controller methods.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
