### PR TITLE
LCAM 1194 Reduced logging level for validation exceptions

### DIFF
--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/exception/RestControllerAdviser.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/exception/RestControllerAdviser.java
@@ -41,7 +41,7 @@ public class RestControllerAdviser {
 
     @ExceptionHandler(ValidationException.class)
     public ResponseEntity<ErrorDTO> handleValidationError(ValidationException ex) {
-        log.error("ValidationException: ", ex);
+        log.warn("ValidationException: ", ex);
         return getNewErrorResponseWith(HttpStatus.BAD_REQUEST, ex.getMessage(), traceIdHandler.getTraceId());
     }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1194)

Set logging level for ValidationExceptions down to warning so won't be reported by Sentry. Deployed branch to DEV to test that ValidationExceptions no longer get reported in Sentry and they dont.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
