### PR TITLE
LCAM-1414

### DIFF
--- a/crime-means-assessment/Dockerfile
+++ b/crime-means-assessment/Dockerfile
@@ -4,5 +4,5 @@ WORKDIR /opt/laa-crime-means-assessment/
 COPY ./build/libs/crime-means-assessment.jar /opt/laa-crime-means-assessment/app.jar
 RUN addgroup -S appgroup && adduser -u 1001 -S appuser -G appgroup
 USER 1001
-EXPOSE 8085 8096
-CMD java -jar app.jar
+EXPOSE 8080 8096
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/crime-means-assessment/Dockerfile
+++ b/crime-means-assessment/Dockerfile
@@ -4,5 +4,5 @@ WORKDIR /opt/laa-crime-means-assessment/
 COPY ./build/libs/crime-means-assessment.jar /opt/laa-crime-means-assessment/app.jar
 RUN addgroup -S appgroup && adduser -u 1001 -S appuser -G appgroup
 USER 1001
-EXPOSE 8080 8096
-ENTRYPOINT ["java","-jar","app.jar"]
+EXPOSE 8085 8096
+CMD java -jar app.jar

--- a/crime-means-assessment/build.gradle
+++ b/crime-means-assessment/build.gradle
@@ -14,7 +14,7 @@ def versions = [
         liquibase                    : "4.29.1",
         crimeCommonsClassesVersion   : "3.18.0",
         crimeCommonsRestClientVersion: "3.4.0",
-        crimeCommonsModsSchemas      : "0.7.0",
+        crimeCommonsModsSchemas      : "1.17.0-SNAPSHOT",
         mockitoInlineVersion         : "5.2.0",
         cucumberVersion              : "7.14.0",
         jUnitPlatformSuiteVersion    : "1.10.0",
@@ -35,6 +35,9 @@ java {
 
 repositories {
     mavenCentral()
+    maven {
+        url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+    }
 }
 
 dependencies {

--- a/crime-means-assessment/build.gradle
+++ b/crime-means-assessment/build.gradle
@@ -14,7 +14,7 @@ def versions = [
         liquibase                    : "4.29.1",
         crimeCommonsClassesVersion   : "3.18.0",
         crimeCommonsRestClientVersion: "3.4.0",
-        crimeCommonsModsSchemas      : "1.17.0-SNAPSHOT",
+        crimeCommonsModsSchemas      : "1.11.1",
         mockitoInlineVersion         : "5.2.0",
         cucumberVersion              : "7.14.0",
         jUnitPlatformSuiteVersion    : "1.10.0",
@@ -35,9 +35,6 @@ java {
 
 repositories {
     mavenCentral()
-    maven {
-        url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-    }
 }
 
 dependencies {

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MaatCourtDataAssessmentBuilder.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MaatCourtDataAssessmentBuilder.java
@@ -1,7 +1,6 @@
 package uk.gov.justice.laa.crime.meansassessment.builder;
 
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.crime.common.model.common.ApiUserSession;
 import uk.gov.justice.laa.crime.common.model.meansassessment.ApiIncomeEvidence;
@@ -19,7 +18,6 @@ import java.util.List;
 
 import static java.util.Optional.ofNullable;
 
-@Slf4j
 @Component
 @AllArgsConstructor
 public class MaatCourtDataAssessmentBuilder {

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MaatCourtDataAssessmentBuilder.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MaatCourtDataAssessmentBuilder.java
@@ -117,7 +117,7 @@ public class MaatCourtDataAssessmentBuilder {
 
     private List<FinancialAssessmentIncomeEvidence> mapIncomeEvidence(List<ApiIncomeEvidence> incomeEvidences,
                                                                       ApiUserSession userSession) {
-        return incomeEvidences.stream()
+        return incomeEvidences == null ? null : incomeEvidences.stream()
                 .map(item -> new FinancialAssessmentIncomeEvidence(
                         item.getId(), item.getDateReceived(), item.getDateModified(), item.getActive(),
                         item.getApiEvidenceType().getCode(), item.getMandatory(), item.getApplicantId(),

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentRequestDTOBuilder.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentRequestDTOBuilder.java
@@ -46,6 +46,7 @@ public class MeansAssessmentRequestDTOBuilder {
             requestDTO.setInitTotalAggregatedIncome(updateMeansAssessmentRequest.getInitTotalAggregatedIncome());
             requestDTO.setFullAssessmentNotes(updateMeansAssessmentRequest.getFullAssessmentNotes());
             requestDTO.setFinancialAssessmentId(updateMeansAssessmentRequest.getFinancialAssessmentId());
+            requestDTO.setIncomeEvidence(updateMeansAssessmentRequest.getIncomeEvidence());
         }
 
         return requestDTO;

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilder.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilder.java
@@ -33,6 +33,7 @@ public class MeansAssessmentResponseBuilder {
                 .withAdjustedIncomeValue(completedAssessment.getAdjustedIncomeValue())
                 .withAssessmentSectionSummary(completedAssessment.getMeansAssessment().getSectionSummaries())
                 .withUpdated(maatApiAssessmentResponse.getUpdated())
+                .withIncomeEvidence(maatApiAssessmentResponse.getIncomeEvidence())
                 .withApplicationTimestamp(completedAssessment.getApplicationTimestamp());
 
         AssessmentType assessmentType = completedAssessment.getMeansAssessment().getAssessmentType();

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/dto/MeansAssessmentRequestDTO.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/dto/MeansAssessmentRequestDTO.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.crime.meansassessment.dto;
 
 import lombok.Builder;
 import lombok.Data;
+import uk.gov.justice.laa.crime.common.model.common.ApiUserSession;
 import uk.gov.justice.laa.crime.common.model.meansassessment.*;
 import uk.gov.justice.laa.crime.enums.*;
 
@@ -42,4 +43,5 @@ public class MeansAssessmentRequestDTO {
     private String fullAssessmentNotes;
     private Integer financialAssessmentId;
     private LocalDateTime timeStamp;
+    private List<ApiIncomeEvidence> incomeEvidence;
 }

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MaatCourtDataAssessmentBuilderTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MaatCourtDataAssessmentBuilderTest.java
@@ -2,13 +2,15 @@ package uk.gov.justice.laa.crime.meansassessment.builder;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
+import uk.gov.justice.laa.crime.common.model.meansassessment.ApiIncomeEvidence;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.FinancialAssessmentIncomeEvidence;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentRequest;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiCreateAssessment;
+import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpdateAssessment;
 import uk.gov.justice.laa.crime.enums.AssessmentType;
 import uk.gov.justice.laa.crime.enums.RequestType;
 import uk.gov.justice.laa.crime.meansassessment.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentDTO;
-import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentRequest;
-import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiCreateAssessment;
-import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpdateAssessment;
 
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -111,12 +113,41 @@ class MaatCourtDataAssessmentBuilderTest {
                         .isEqualTo(assessmentDTO.getTotalAggregatedExpense());
                 assertThat(updateRequest.getUserModified())
                         .isEqualTo(assessmentDTO.getMeansAssessment().getUserSession().getUserName());
+                checkEvidenceFields(updateRequest.getFinAssIncomeEvidences().get(0),
+                        assessmentDTO.getMeansAssessment().getIncomeEvidence().get(0));
             };
         } else {
             updateRequirements = updateRequest -> assertThat(updateRequest.getUserModified())
                     .isEqualTo(assessmentDTO.getMeansAssessment().getUserSession().getUserName());
         }
         assertThat(resultDto).isInstanceOfSatisfying(MaatApiUpdateAssessment.class, updateRequirements);
+    }
+
+    private void checkEvidenceFields(FinancialAssessmentIncomeEvidence finAssIncomeEvidence, ApiIncomeEvidence incomeEvidence) {
+        SoftAssertions.assertSoftly(softly -> {
+            assertThat(finAssIncomeEvidence.getId())
+                    .isEqualTo(incomeEvidence.getId());
+            assertThat(finAssIncomeEvidence.getDateModified())
+                    .isEqualTo(incomeEvidence.getDateModified());
+            assertThat(finAssIncomeEvidence.getDateReceived())
+                    .isEqualTo(incomeEvidence.getDateReceived());
+            assertThat(finAssIncomeEvidence.getActive())
+                    .isEqualTo(incomeEvidence.getActive());
+            assertThat(finAssIncomeEvidence.getAdhoc())
+                    .isEqualTo(incomeEvidence.getAdhoc());
+            assertThat(finAssIncomeEvidence.getApplicant())
+                    .isEqualTo(incomeEvidence.getApplicantId());
+            assertThat(finAssIncomeEvidence.getMandatory())
+                    .isEqualTo(incomeEvidence.getMandatory());
+            assertThat(finAssIncomeEvidence.getOtherText())
+                    .isEqualTo(incomeEvidence.getOtherText());
+            assertThat(finAssIncomeEvidence.getIncomeEvidence())
+                    .isEqualTo(incomeEvidence.getApiEvidenceType().getCode());
+            assertThat(finAssIncomeEvidence.getUserCreated())
+                    .isEqualTo(assessmentDTO.getMeansAssessment().getUserSession().getUserName());
+            assertThat(finAssIncomeEvidence.getUserModified())
+                    .isEqualTo(assessmentDTO.getMeansAssessment().getUserSession().getUserName());
+        });
     }
 
     @Test

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/data/builder/TestModelDataBuilder.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/data/builder/TestModelDataBuilder.java
@@ -84,6 +84,7 @@ public class TestModelDataBuilder {
 
     public static final CurrentStatus TEST_ASSESSMENT_STATUS = CurrentStatus.COMPLETE;
 
+    public static final int APPLICANT_ID = 12;
     public static final LocalDateTime TEST_INCOME_UPLIFT_APPLY_DATE =
             LocalDateTime.of(2021, 12, 12, 0, 0, 0);
 
@@ -232,7 +233,7 @@ public class TestModelDataBuilder {
                 .withAssessmentType(AssessmentType.INIT)
                 .withRepId(isValid ? 91919 : null)
                 .withCmuId(isValid ? 91919 : null)
-                .withInitialAssessmentDate(LocalDateTime.of(2021, 12, 16, 10, 0))
+                .withInitialAssessmentDate(LocalDateTime.of(2021, APPLICANT_ID, 16, 10, 0))
                 .withIncomeEvidenceSummary(getApiIncomeEvidenceSummary())
                 .withOtherBenefitNote(TEST_NOTE)
                 .withOtherIncomeNote(TEST_NOTE)
@@ -333,7 +334,22 @@ public class TestModelDataBuilder {
                 .fullAssessmentDate(LocalDateTime.of(2021, 12, 16, 10, 0))
                 .financialAssessmentId(TEST_FINANCIAL_ASSESSMENT_ID)
                 .eligibilityCheckRequired(false)
+                .incomeEvidence(getApiIncomeEvidence())
                 .build();
+    }
+
+    private static List<ApiIncomeEvidence> getApiIncomeEvidence() {
+        return List.of(new ApiIncomeEvidence()
+                .withApiEvidenceType(new ApiEvidenceType().withCode("Mock Evidence Code").withDescription("Mock Evidence Description"))
+                .withAdhoc("Y")
+                .withId(678)
+                .withApplicantId(APPLICANT_ID)
+                .withActive("Y")
+                .withMandatory("Y")
+                .withOtherText("Other text")
+                .withDateModified(LocalDateTime.of(2021, 12, 11, 10, 0))
+                .withDateReceived(TEST_DATE_CREATED)
+        );
     }
 
     public static ApiCrownCourtOverview getApiCrownCourtOverview() {
@@ -736,7 +752,7 @@ public class TestModelDataBuilder {
 
     public static ApplicantDTO getApplicantDTO() {
         return ApplicantDTO.builder()
-                .id(12)
+                .id(APPLICANT_ID)
                 .build();
     }
 

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/data/builder/TestModelDataBuilder.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/data/builder/TestModelDataBuilder.java
@@ -233,7 +233,7 @@ public class TestModelDataBuilder {
                 .withAssessmentType(AssessmentType.INIT)
                 .withRepId(isValid ? 91919 : null)
                 .withCmuId(isValid ? 91919 : null)
-                .withInitialAssessmentDate(LocalDateTime.of(2021, APPLICANT_ID, 16, 10, 0))
+                .withInitialAssessmentDate(LocalDateTime.of(2021, 12, 16, 10, 0))
                 .withIncomeEvidenceSummary(getApiIncomeEvidenceSummary())
                 .withOtherBenefitNote(TEST_NOTE)
                 .withOtherIncomeNote(TEST_NOTE)

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/data/builder/TestModelDataBuilder.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/data/builder/TestModelDataBuilder.java
@@ -1,15 +1,34 @@
 package uk.gov.justice.laa.crime.meansassessment.data.builder;
 
 import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.crime.common.model.common.ApiUserSession;
+import uk.gov.justice.laa.crime.common.model.meansassessment.*;
 import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiAssessmentResponse;
-import uk.gov.justice.laa.crime.common.model.meansassessment.maatapi.MaatApiUpdateAssessment;
-import uk.gov.justice.laa.crime.enums.*;
+import uk.gov.justice.laa.crime.enums.AssessmentType;
+import uk.gov.justice.laa.crime.enums.CaseType;
+import uk.gov.justice.laa.crime.enums.CurrentStatus;
+import uk.gov.justice.laa.crime.enums.Frequency;
+import uk.gov.justice.laa.crime.enums.FullAssessmentResult;
+import uk.gov.justice.laa.crime.enums.InitAssessmentResult;
+import uk.gov.justice.laa.crime.enums.MagCourtOutcome;
+import uk.gov.justice.laa.crime.enums.NewWorkReason;
+import uk.gov.justice.laa.crime.enums.ReviewType;
 import uk.gov.justice.laa.crime.meansassessment.dto.AssessmentDTO;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentDTO;
 import uk.gov.justice.laa.crime.meansassessment.dto.MeansAssessmentRequestDTO;
-import uk.gov.justice.laa.crime.meansassessment.dto.maatcourtdata.*;
-import uk.gov.justice.laa.crime.common.model.meansassessment.*;
-import uk.gov.justice.laa.crime.meansassessment.staticdata.entity.*;
+import uk.gov.justice.laa.crime.meansassessment.dto.maatcourtdata.ApplicantDTO;
+import uk.gov.justice.laa.crime.meansassessment.dto.maatcourtdata.ChildWeightings;
+import uk.gov.justice.laa.crime.meansassessment.dto.maatcourtdata.FinAssIncomeEvidenceDTO;
+import uk.gov.justice.laa.crime.meansassessment.dto.maatcourtdata.FinancialAssessmentDTO;
+import uk.gov.justice.laa.crime.meansassessment.dto.maatcourtdata.FinancialAssessmentDetails;
+import uk.gov.justice.laa.crime.meansassessment.dto.maatcourtdata.RepOrderDTO;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.entity.AssessmentCriteriaChildWeightingEntity;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.entity.AssessmentCriteriaDetailEntity;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.entity.AssessmentCriteriaDetailFrequencyEntity;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.entity.AssessmentCriteriaEntity;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.entity.AssessmentDetailEntity;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.entity.CaseTypeAssessmentCriteriaDetailValueEntity;
+import uk.gov.justice.laa.crime.meansassessment.staticdata.entity.IncomeEvidenceEntity;
 import uk.gov.justice.laa.crime.meansassessment.staticdata.enums.Section;
 
 import java.math.BigDecimal;
@@ -262,15 +281,6 @@ public class TestModelDataBuilder {
                         )
                 )
                 .withSectionSummaries(List.of(getApiAssessmentSectionSummary()));
-    }
-
-    public static MaatApiUpdateAssessment getMaatApiRollbackAssessment() {
-        return new MaatApiUpdateAssessment()
-                .withFinancialAssessmentId(MEANS_ASSESSMENT_ID)
-                .withFassFullStatus("FAIL")
-                .withFassInitStatus("FAIL")
-                .withInitResult(InitAssessmentResult.FAIL.getResult())
-                .withFullResult(FullAssessmentResult.FAIL.getResult());
     }
 
     public static ApiUpdateMeansAssessmentRequest getApiUpdateMeansAssessmentRequest(boolean isValid) {


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1414)

- Fixed run command in `Dockerfile` to enable local debugging.
- Enable the passing of income evidence records to the Court Data API when updating an assessment.
  - This required updating a DTO and mapping logic to align with the related schema [changes](https://github.com/ministryofjustice/laa-crime-commons/pull/144) in crime-commons.

### Outstanding:

- The `MeansAssessmentResponseBuilder` still needs to be updated to pass back the income evidence records returned from the Court Data API to the Orchestration service.
- There are also a number of failing test cases that need to be fixed.

