### PR TITLE
LCAM 1621 Persist Income Evidence

### DIFF
--- a/crime-means-assessment/build.gradle
+++ b/crime-means-assessment/build.gradle
@@ -14,7 +14,7 @@ def versions = [
         liquibase                    : "4.29.1",
         crimeCommonsClassesVersion   : "3.18.0",
         crimeCommonsRestClientVersion: "3.18.0",
-        crimeCommonsModsSchemas      : "1.11.1",
+        crimeCommonsModsSchemas      : "1.19.0-SNAPSHOT",
         mockitoInlineVersion         : "5.2.0",
         cucumberVersion              : "7.20.0",
         jUnitPlatformSuiteVersion    : "1.10.0",
@@ -35,6 +35,9 @@ java {
 
 repositories {
     mavenCentral()
+    maven {
+        url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+    }
 }
 
 dependencies {

--- a/crime-means-assessment/build.gradle
+++ b/crime-means-assessment/build.gradle
@@ -14,7 +14,7 @@ def versions = [
         liquibase                    : "4.29.1",
         crimeCommonsClassesVersion   : "3.18.0",
         crimeCommonsRestClientVersion: "3.18.0",
-        crimeCommonsModsSchemas      : "1.19.0-SNAPSHOT",
+        crimeCommonsModsSchemas      : "1.20.1",
         mockitoInlineVersion         : "5.2.0",
         cucumberVersion              : "7.20.0",
         jUnitPlatformSuiteVersion    : "1.10.0",

--- a/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilder.java
+++ b/crime-means-assessment/src/main/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilder.java
@@ -34,7 +34,8 @@ public class MeansAssessmentResponseBuilder {
                 .withAssessmentSectionSummary(completedAssessment.getMeansAssessment().getSectionSummaries())
                 .withUpdated(maatApiAssessmentResponse.getUpdated())
                 .withIncomeEvidence(maatApiAssessmentResponse.getIncomeEvidence())
-                .withApplicationTimestamp(completedAssessment.getApplicationTimestamp());
+                .withApplicationTimestamp(completedAssessment.getApplicationTimestamp())
+                .withDateCompleted(maatApiAssessmentResponse.getDateCompleted());
 
         AssessmentType assessmentType = completedAssessment.getMeansAssessment().getAssessmentType();
         if (AssessmentType.FULL.equals(assessmentType)) {

--- a/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilderTest.java
+++ b/crime-means-assessment/src/test/java/uk/gov/justice/laa/crime/meansassessment/builder/MeansAssessmentResponseBuilderTest.java
@@ -49,6 +49,7 @@ class MeansAssessmentResponseBuilderTest {
                     .isEqualTo(completedAssessment.getAdjustedIncomeValue());
             assertThat(response.getAssessmentSectionSummary())
                     .isEqualTo(completedAssessment.getMeansAssessment().getSectionSummaries());
+            assertThat(response.getDateCompleted()).isEqualTo(maatApiAssessmentResponse.getDateCompleted());
         });
     }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1621)

- Amended MeansAssessmentResponseBuilder to return DateCompleted so that it can be accessed from orchestrator when mapping the update financial assessment call following creation of default evidence items.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.