### PR TITLE
LASB-4085 - Disable prod ingress and add ModSecurity to non-prod 

### DIFF
--- a/helm_deploy/laa-crime-means-assessment/values-dev.yaml
+++ b/helm_deploy/laa-crime-means-assessment/values-dev.yaml
@@ -46,12 +46,17 @@ ingress:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apps-team,tag:namespace=laa-crime-means-assessment-dev"
   externalAnnotations: {}
   hosts:
     - host: laa-crime-means-assessment-dev.apps.live.cloud-platform.service.justice.gov.uk
       paths: ["/"]
   tls: []
-  className: default
+  className: modsec-non-prod
 
 autoscaling:
   enabled: false

--- a/helm_deploy/laa-crime-means-assessment/values-prod.yaml
+++ b/helm_deploy/laa-crime-means-assessment/values-prod.yaml
@@ -40,18 +40,7 @@ service:
   targetPort: 8080
 
 ingress:
-  enabled: true
-  environmentName: laa-crime-means-assessment-prod
-  annotations:
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
-    nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
-  externalAnnotations: {}
-  hosts:
-    - host: laa-crime-means-assessment-prod.apps.live.cloud-platform.service.justice.gov.uk
-      paths: ["/open-api/"]
-  tls: []
-  className: default
+  enabled: false
 
 autoscaling:
   enabled: false

--- a/helm_deploy/laa-crime-means-assessment/values-test.yaml
+++ b/helm_deploy/laa-crime-means-assessment/values-test.yaml
@@ -1,1 +1,99 @@
-# Default values for laa-crime-means-assessment.# This is a YAML-formatted file.# Declare variables to be passed into your templates.replicaCount: 2image:  repository: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-crime-apps-team/laa-crime-means-assessment-dev-ecr  pullPolicy: IfNotPresent  # Overrides the image tag whose default is the chart appVersion.  # tag: latestsentry:  sampleRate: 0.05aws_region: eu-west-2java:  host_env: testjwt:  issuerUri: https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_Bo3WVvzAkmaatApi:  baseUrl: https://maat-cd-api.tst.legalservices.gov.uk/api/internal/v1/assessment  oauthUrl: https://maat-cd-api-tst.auth.eu-west-2.amazoncognito.com/oauth2/tokenserviceAccount:  # Specifies whether a service account should be created  create: false  # Annotations to add to the service account  annotations: {}  # The name of the service account to use.  # If not set and create is true, a name is generated using the fullname template  name: "laa-crime-means-assessment"service:  type: ClusterIP  port: 80  targetPort: 8080ingress:  enabled: true  environmentName: laa-crime-means-assessment-test  annotations:    external-dns.alpha.kubernetes.io/aws-weight: "100"    nginx.ingress.kubernetes.io/affinity: "cookie"    nginx.ingress.kubernetes.io/session-cookie-max-age: "300"  externalAnnotations: {}  hosts:    - host: laa-crime-means-assessment-test.apps.live.cloud-platform.service.justice.gov.uk      paths: ["/"]  tls: []  className: defaultautoscaling:  enabled: false  minReplicas: 1  maxReplicas: 100  targetCPUUtilizationPercentage: 80  targetMemoryUtilizationPercentage: 80actuator:  metrics:    enabled: true    scrapeInterval: 15s    path: /actuator/prometheus  health:    path: /actuator/health  port: 8096  liveness:    initialDelaySeconds: 45    periodSeconds: 10    timeoutSeconds: 10    failureThreshold: 5  readiness:    initialDelaySeconds: 45    periodSeconds: 10    timeoutSeconds: 10    failureThreshold: 5scheduledDowntime:  enabled: true  # Start at 6am UTC Monday-Friday  startup: '0 6 * * 1-5'  # Stop at 10pm UTC Monday-Friday  shutdown: '0 22 * * 1-5'  serviceAccountName: scheduled-downtime-serviceaccountsecurityContext:  allowPrivilegeEscalation: false  capabilities:    drop: ["ALL"]  runAsNonRoot: true  seccompProfile:    type: RuntimeDefaultlogging:  level: INFO
+# Default values for laa-crime-means-assessment.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 2
+
+image:
+  repository: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-crime-apps-team/laa-crime-means-assessment-dev-ecr
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  # tag: latest
+
+sentry:
+  sampleRate: 0.05
+
+aws_region: eu-west-2
+
+java:
+  host_env: test
+
+jwt:
+  issuerUri: https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_Bo3WVvzAk
+
+maatApi:
+  baseUrl: https://maat-cd-api.tst.legalservices.gov.uk/api/internal/v1/assessment
+  oauthUrl: https://maat-cd-api-tst.auth.eu-west-2.amazoncognito.com/oauth2/token
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "laa-crime-means-assessment"
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+ingress:
+  enabled: true
+  environmentName: laa-crime-means-assessment-test
+  annotations:
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
+  externalAnnotations: {}
+  hosts:
+    - host: laa-crime-means-assessment-test.apps.live.cloud-platform.service.justice.gov.uk
+      paths: ["/"]
+  tls: []
+  className: default
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+actuator:
+  metrics:
+    enabled: true
+    scrapeInterval: 15s
+    path: /actuator/prometheus
+  health:
+    path: /actuator/health
+  port: 8096
+  liveness:
+    initialDelaySeconds: 45
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 5
+  readiness:
+    initialDelaySeconds: 45
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 5
+
+scheduledDowntime:
+  enabled: true
+  # Start at 6am UTC Monday-Friday
+  startup: '0 6 * * 1-5'
+  # Stop at 10pm UTC Monday-Friday
+  shutdown: '0 22 * * 1-5'
+  serviceAccountName: scheduled-downtime-serviceaccount
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+logging:
+  level: INFO

--- a/helm_deploy/laa-crime-means-assessment/values-test.yaml
+++ b/helm_deploy/laa-crime-means-assessment/values-test.yaml
@@ -46,12 +46,17 @@ ingress:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apps-team,tag:namespace=laa-crime-means-assessment-test"
   externalAnnotations: {}
   hosts:
     - host: laa-crime-means-assessment-test.apps.live.cloud-platform.service.justice.gov.uk
       paths: ["/"]
   tls: []
-  className: default
+  className: modsec-non-prod
 
 autoscaling:
   enabled: false

--- a/helm_deploy/laa-crime-means-assessment/values-uat.yaml
+++ b/helm_deploy/laa-crime-means-assessment/values-uat.yaml
@@ -46,12 +46,17 @@ ingress:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apps-team,tag:namespace=laa-crime-means-assessment-uat"
   externalAnnotations: {}
   hosts:
     - host: laa-crime-means-assessment-uat.apps.live.cloud-platform.service.justice.gov.uk
       paths: ["/"]
   tls: []
-  className: default
+  className: modsec-non-prod
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4085)

Disabled the ingress in prod and added ModSecurity to non-prod.

Please note, with the ModSecurity I have set it to DetectionOnly - This means requests won't be blocked, but will still be logged. This way we can monitor for a while and ensure it's not causing any false-positives before we start blocking requests.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.