### PR TITLE
[LASB-4144] Pull the internal IP allowlist from a secret

### DIFF
--- a/helm_deploy/laa-crime-means-assessment/templates/_helpers.tpl
+++ b/helm_deploy/laa-crime-means-assessment/templates/_helpers.tpl
@@ -61,3 +61,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create ingress configuration
+*/}}
+{{- define "laa-crime-means-assessment.ingress" -}}
+{{- $internalAllowlistSourceRange := (lookup "v1" "Secret" .Release.Namespace "ingress-internal-allowlist-source-range").data.INTERNAL_ALLOWLIST_SOURCE_RANGE | b64dec }}
+{{- if $internalAllowlistSourceRange }}
+  nginx.ingress.kubernetes.io/whitelist-source-range: {{ $internalAllowlistSourceRange }}
+  external-dns.alpha.kubernetes.io/set-identifier: {{ include "laa-crime-means-assessment.fullname" . }}-{{ $.Values.ingress.environmentName}}-green
+{{- end }}
+{{- end }}

--- a/helm_deploy/laa-crime-means-assessment/templates/ingress.yaml
+++ b/helm_deploy/laa-crime-means-assessment/templates/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-    external-dns.alpha.kubernetes.io/set-identifier: {{ $fullName }}-{{ $.Values.ingress.environmentName}}-green
+  {{- include "laa-crime-means-assessment.ingress" . | nindent 2 }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4144)

Added configuration to the ingress to include an IP allowlist, which is pulled from a secret. This is only applicable to the non-prod environments, as we have the ingress disabled for production.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.